### PR TITLE
Add Linux support: rendering fix, keyboard, clipboard

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -57,6 +57,24 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
 
 [[package]]
 name = "autocfg"
@@ -160,6 +178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +270,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix 0.31.3",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -274,14 +301,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fastrand"
@@ -294,6 +333,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -411,6 +462,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,10 +483,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "instant"
@@ -444,6 +530,7 @@ name = "ioscpy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "block",
  "cc",
  "clap",
@@ -453,7 +540,7 @@ dependencies = [
  "objc",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "zune-jpeg",
 ]
 
@@ -511,7 +598,7 @@ dependencies = [
  "bitflags 2.13.0",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -519,6 +606,21 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "malloc_buf"
@@ -563,9 +665,9 @@ dependencies = [
  "serde_derive",
  "tempfile",
  "wasm-bindgen-futures",
- "wayland-client",
+ "wayland-client 0.29.5",
  "wayland-cursor",
- "wayland-protocols",
+ "wayland-protocols 0.29.5",
  "winapi",
  "x11-dl",
 ]
@@ -595,6 +697,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,10 +724,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -639,6 +808,56 @@ dependencies = [
  "libc",
  "libredox",
  "sdl2",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
 ]
 
 [[package]]
@@ -669,6 +888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +919,15 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
@@ -708,7 +945,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -722,6 +959,12 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdl2"
@@ -834,7 +1077,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -843,7 +1086,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -855,6 +1107,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -931,6 +1205,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys 0.31.11",
+]
+
+[[package]]
 name = "wayland-client"
 version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,8 +1229,20 @@ dependencies = [
  "nix 0.24.3",
  "scoped-tls",
  "wayland-commons",
- "wayland-scanner",
- "wayland-sys",
+ "wayland-scanner 0.29.5",
+ "wayland-sys 0.29.5",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner 0.31.10",
 ]
 
 [[package]]
@@ -955,7 +1254,7 @@ dependencies = [
  "nix 0.24.3",
  "once_cell",
  "smallvec",
- "wayland-sys",
+ "wayland-sys 0.29.5",
 ]
 
 [[package]]
@@ -965,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
 dependencies = [
  "nix 0.24.3",
- "wayland-client",
+ "wayland-client 0.29.5",
  "xcursor",
 ]
 
@@ -976,9 +1275,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
  "bitflags 1.3.2",
- "wayland-client",
+ "wayland-client 0.29.5",
  "wayland-commons",
- "wayland-scanner",
+ "wayland-scanner 0.29.5",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client 0.31.14",
+ "wayland-scanner 0.31.10",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client 0.31.14",
+ "wayland-protocols 0.32.13",
+ "wayland-scanner 0.31.10",
 ]
 
 [[package]]
@@ -993,6 +1317,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
 name = "wayland-sys"
 version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1335,15 @@ checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
 dependencies = [
  "dlib",
  "lazy_static",
+ "pkg-config",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
  "pkg-config",
 ]
 
@@ -1043,11 +1387,103 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client 0.31.14",
+ "wayland-protocols 0.32.13",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]
@@ -1060,6 +1496,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xcursor"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -31,6 +31,11 @@ objc = "0.2"
 block = "0.1"
 cocoa = "0.25"
 
+# Host clipboard on Linux/Windows (macOS uses NSPasteboard directly). Text only,
+# so image-data is dropped; wayland-data-control adds Wayland alongside X11.
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cc = "1"
 

--- a/host/src/clipboard.rs
+++ b/host/src/clipboard.rs
@@ -100,15 +100,49 @@ pub const MAX_CLIPBOARD_BYTES: usize = 1 << 20;
 #[cfg(target_os = "macos")]
 pub use platform::{change_count, read_text, write_text};
 
+/// Linux/Windows clipboard via `arboard`. The handle is kept alive for the whole
+/// process: on Wayland/X11 we must keep owning the selection while it's ours.
+/// arboard has no change counter like NSPasteboard, so we derive one from the
+/// content hash: a real edit flips it, and our own writes (same hash) don't echo
+/// back to the device. The anti-echo relies on `arboard` round-tripping text
+/// unchanged (true for plain UTF-8); `change_count` is not a cheap counter here,
+/// it reads the clipboard, so the caller's poll interval should stay coarse.
 #[cfg(not(target_os = "macos"))]
-pub fn change_count() -> i64 {
-    0
+mod platform {
+    use std::sync::{Mutex, OnceLock};
+
+    use super::hash_text;
+
+    fn clipboard() -> Option<&'static Mutex<arboard::Clipboard>> {
+        static CLIP: OnceLock<Option<Mutex<arboard::Clipboard>>> = OnceLock::new();
+        CLIP.get_or_init(|| arboard::Clipboard::new().ok().map(Mutex::new))
+            .as_ref()
+    }
+
+    pub fn read_text() -> Option<String> {
+        let mut clip = clipboard()?.lock().ok()?;
+        match clip.get_text() {
+            Ok(text) if !text.is_empty() => Some(text),
+            _ => None,
+        }
+    }
+
+    pub fn write_text(text: &str) -> i64 {
+        if let Some(clip) = clipboard() {
+            if let Ok(mut clip) = clip.lock() {
+                let _ = clip.set_text(text.to_owned());
+            }
+        }
+        hash_text(text) as i64
+    }
+
+    pub fn change_count() -> i64 {
+        match read_text() {
+            Some(text) => hash_text(&text) as i64,
+            None => 0,
+        }
+    }
 }
+
 #[cfg(not(target_os = "macos"))]
-pub fn read_text() -> Option<String> {
-    None
-}
-#[cfg(not(target_os = "macos"))]
-pub fn write_text(_text: &str) -> i64 {
-    0
-}
+pub use platform::{change_count, read_text, write_text};

--- a/host/src/window.rs
+++ b/host/src/window.rs
@@ -228,6 +228,123 @@ fn install_key_monitor(tx: Sender<InputFrame>, clip: Arc<Mutex<ClipState>>) {
 #[cfg(not(target_os = "macos"))]
 fn install_key_monitor(_tx: Sender<InputFrame>, _clip: Arc<Mutex<ClipState>>) {}
 
+/// Forwards typed characters from minifb's input callback to the device as text.
+/// It tracks Ctrl from the same key-event stream (via `set_key_state`) and drops
+/// characters while Ctrl is held, so a shortcut like Ctrl+C isn't also typed. This
+/// is needed because minifb's backends disagree: X11 hands us a C0 control code for
+/// Ctrl+letter (caught by `is_control`), but Wayland resolves the bare keysym and
+/// hands us the plain letter, which `is_control` wouldn't catch.
+#[cfg(not(target_os = "macos"))]
+struct TextForwarder {
+    tx: Sender<InputFrame>,
+    ctrl: bool,
+}
+
+#[cfg(not(target_os = "macos"))]
+impl minifb::InputCallback for TextForwarder {
+    fn add_char(&mut self, uni_char: u32) {
+        if self.ctrl {
+            return;
+        }
+        if let Some(c) = char::from_u32(uni_char) {
+            if !c.is_control() {
+                let _ = self
+                    .tx
+                    .send(InputFrame::new(MessageType::InputText, protocol::encode_text(&c.to_string())));
+            }
+        }
+    }
+
+    fn set_key_state(&mut self, key: minifb::Key, state: bool) {
+        if matches!(key, minifb::Key::LeftCtrl | minifb::Key::RightCtrl) {
+            self.ctrl = state;
+        }
+    }
+}
+
+/// Register text-input forwarding on the window. minifb's callback is per-window,
+/// so this must run again after the window is recreated on rotation. macOS uses
+/// the global `install_key_monitor` instead, so there it's a no-op.
+#[cfg(not(target_os = "macos"))]
+fn attach_text_input(window: &mut Window, tx: &Sender<InputFrame>) {
+    window.set_input_callback(Box::new(TextForwarder {
+        tx: tx.clone(),
+        ctrl: false,
+    }));
+}
+
+#[cfg(target_os = "macos")]
+fn attach_text_input(_window: &mut Window, _tx: &Sender<InputFrame>) {}
+
+/// Poll this frame's keys and forward shortcuts and editing keys, mirroring the
+/// macOS monitor but with Ctrl as the modifier (macOS uses Cmd). Text itself goes
+/// through `TextForwarder`; here we handle Esc (back), Enter/Tab, the repeating
+/// Backspace/arrows, and the Ctrl combos. macOS routes all of this through
+/// `install_key_monitor`, so this is Linux/Windows only.
+#[cfg(not(target_os = "macos"))]
+fn pump_keys(window: &Window, tx: &Sender<InputFrame>, clip: &Arc<Mutex<ClipState>>) {
+    use crate::protocol::KeyCode;
+    use minifb::{Key, KeyRepeat};
+
+    let ctrl = window.is_key_down(Key::LeftCtrl) || window.is_key_down(Key::RightCtrl);
+
+    // One-shot keys: shortcuts and the editing keys that shouldn't auto-repeat.
+    for key in window.get_keys_pressed(KeyRepeat::No) {
+        if ctrl {
+            match key {
+                Key::J => send_action(tx, SystemAction::Home),
+                Key::L => send_action(tx, SystemAction::Lock),
+                Key::T => send_action(tx, SystemAction::AppSwitcher),
+                Key::R => send_action(tx, SystemAction::RotateLeft),
+                Key::A => send_key(tx, KeyCode::SelectAll),
+                Key::C => send_key(tx, KeyCode::Copy),
+                Key::V => {
+                    // Push the host clipboard to the device then paste, so a
+                    // cross-device paste works. Falls back to a plain iOS paste if
+                    // the host clipboard isn't usable text (empty, or no display).
+                    match clipboard::read_text() {
+                        Some(text)
+                            if !text.is_empty() && text.len() <= clipboard::MAX_CLIPBOARD_BYTES =>
+                        {
+                            if let Ok(mut st) = clip.lock() {
+                                st.last_synced_hash = Some(clipboard::hash_text(&text));
+                            }
+                            send_clipboard_set(tx, &text, true);
+                        }
+                        _ => send_key(tx, KeyCode::Paste),
+                    }
+                }
+                Key::X => send_key(tx, KeyCode::Cut),
+                Key::Z => send_key(tx, KeyCode::Undo),
+                _ => {}
+            }
+        } else {
+            match key {
+                Key::Escape => send_action(tx, SystemAction::Back),
+                Key::Enter | Key::NumPadEnter => send_key(tx, KeyCode::Enter),
+                Key::Tab => send_key(tx, KeyCode::Tab),
+                _ => {}
+            }
+        }
+    }
+
+    // Repeating keys: held Backspace and arrows keep firing. On a key's first frame
+    // it shows up in both KeyRepeat::No and ::Yes, so these keys must stay out of the
+    // one-shot match above, or they'd fire twice that frame. Keep the two sets disjoint.
+    if !ctrl {
+        for key in window.get_keys_pressed(KeyRepeat::Yes) {
+            match key {
+                Key::Backspace => send_key(tx, KeyCode::Backspace),
+                Key::Left => send_key(tx, KeyCode::Left),
+                Key::Right => send_key(tx, KeyCode::Right),
+                Key::Up => send_key(tx, KeyCode::Up),
+                Key::Down => send_key(tx, KeyCode::Down),
+                _ => {}
+            }
+        }
+    }
+}
+
 /// Window size for a `w`x`h` device frame at the given scale, clamped to at most
 /// about 92% of the screen while keeping the aspect ratio.
 fn scaled_fit(w: usize, h: usize, scale: f32) -> (usize, usize) {
@@ -253,9 +370,9 @@ fn open_window(title: &str, w: usize, h: usize) -> Result<Window> {
         h,
         WindowOptions {
             resize: true,
-            // We hand minifb a device-aspect, bilinear-scaled buffer, and
-            // AspectRatioStretch letterboxes it so it never distorts on resize.
-            scale_mode: ScaleMode::AspectRatioStretch,
+            // The buffer we present is already window-sized and letterboxed (see
+            // `scale_frame`), so Stretch blits it 1:1.
+            scale_mode: ScaleMode::Stretch,
             ..WindowOptions::default()
         },
     )
@@ -346,21 +463,28 @@ fn screen_visible_size() -> (f64, f64) {
     (1440.0, 900.0)
 }
 
-/// Bilinearly scale `src` into `dst`, keeping the device aspect ratio and fitting
-/// within `max_w`x`max_h`. Returns the produced dimensions. The buffer is always
-/// the device's aspect (never the window's), so AspectRatioStretch letterboxes it
-/// and it can't distort whatever shape the window is.
+/// Bilinearly scale `src` into a full `out_w`x`out_h` buffer, keeping the device
+/// aspect ratio and centering it with black bars (letterbox). Returns `(out_w,
+/// out_h)`. The buffer is window-sized so the caller can blit it 1:1 with
+/// `Stretch`: minifb's `AspectRatioStretch` can't do the letterboxing for us, as
+/// its POSIX scaler shears the image when the buffer is taller than the window
+/// (it swaps width/height into `image_resize_linear_stride`).
 fn scale_frame(
     src: &DecodedFrame,
-    max_w: usize,
-    max_h: usize,
+    out_w: usize,
+    out_h: usize,
     dst: &mut Vec<u32>,
 ) -> (usize, usize) {
-    let scale = (max_w as f32 / src.width as f32).min(max_h as f32 / src.height as f32);
-    let dw = ((src.width as f32 * scale) as usize).clamp(1, max_w.max(1));
-    let dh = ((src.height as f32 * scale) as usize).clamp(1, max_h.max(1));
+    let out_w = out_w.max(1);
+    let out_h = out_h.max(1);
     dst.clear();
-    dst.resize(dw * dh, 0);
+    dst.resize(out_w * out_h, 0);
+
+    let scale = (out_w as f32 / src.width as f32).min(out_h as f32 / src.height as f32);
+    let dw = ((src.width as f32 * scale) as usize).clamp(1, out_w);
+    let dh = ((src.height as f32 * scale) as usize).clamp(1, out_h);
+    let x_off = (out_w - dw) / 2;
+    let y_off = (out_h - dh) / 2;
 
     let inv_x = src.width as f32 / dw as f32;
     let inv_y = src.height as f32 / dh as f32;
@@ -373,7 +497,7 @@ fn scale_frame(
         let wy = fy - y0 as f32;
         let srow0 = y0 * src.width;
         let srow1 = y1 * src.width;
-        let drow = y * dw;
+        let drow = (y + y_off) * out_w + x_off;
         for x in 0..dw {
             let fx = ((x as f32 + 0.5) * inv_x - 0.5).max(0.0);
             let x0 = (fx as usize).min(last_x);
@@ -389,7 +513,7 @@ fn scale_frame(
             );
         }
     }
-    (dw, dh)
+    (out_w, out_h)
 }
 
 /// Bilinear blend of four `0x00RRGGBB` pixels.
@@ -438,6 +562,7 @@ pub fn run_window(
     let mut window = open_window(title, win_w, win_h)?;
     let clip = Arc::new(Mutex::new(ClipState::default()));
     install_key_monitor(input_tx.clone(), clip.clone());
+    attach_text_input(&mut window, &input_tx);
 
     let mut current = first;
     let mut last_dims = (current.width, current.height);
@@ -459,22 +584,24 @@ pub fn run_window(
             let pos = window.get_position();
             if let Ok(mut w) = open_window(title, nw, nh) {
                 w.set_position(pos.0, pos.1);
+                attach_text_input(&mut w, &input_tx);
                 window = w;
             }
         }
 
         pump_input(&window, &current, &mut input, &input_tx);
+        #[cfg(not(target_os = "macos"))]
+        pump_keys(&window, &input_tx, &clip);
 
-        // Bilinear-scale the frame to the window's backing (retina) resolution,
-        // keeping the device aspect. minifb's own scaler is nearest-neighbor, so
-        // matching backing pixels keeps it sharp, and AspectRatioStretch just
-        // letterboxes our device-aspect buffer so it never distorts. Capped so a
-        // huge window can't blow up the per-frame resize cost.
+        // Render a window-sized, letterboxed buffer at the backing (retina)
+        // resolution for minifb to blit 1:1. Both axes are capped together so a
+        // huge window keeps its aspect (and per-frame cost bounded) under Stretch.
         let (gw, gh) = window.get_size();
         let bs = backing_scale(&window);
-        let max_w = (((gw as f32 * bs) as usize).max(1)).min(2600);
-        let max_h = (((gh as f32 * bs) as usize).max(1)).min(2600);
-        let (bw, bh) = scale_frame(&current, max_w, max_h, &mut scaled);
+        let ow = (gw as f32 * bs).max(1.0);
+        let oh = (gh as f32 * bs).max(1.0);
+        let down = (2600.0 / ow).min(2600.0 / oh).min(1.0);
+        let (bw, bh) = scale_frame(&current, (ow * down) as usize, (oh * down) as usize, &mut scaled);
 
         window
             .update_with_buffer(&scaled, bw, bh)


### PR DESCRIPTION
## Summary

Makes the `host/` Rust CLI build and run on Linux (developed and tested on
Debian, KDE/Wayland). The keyboard and clipboard additions are gated behind
`cfg(not(target_os = "macos"))`, so those macOS paths are untouched. The
rendering change is in shared code, so it also affects the macOS build (see the
note below).

The README states the tool is macOS-only, so this is an opt-in scope expansion.
Happy to reframe, split, or drop parts if Linux isn't a direction you want.

### What works on Linux now
- Screen mirror and mouse (tap, swipe)
- Keyboard, text input (any layout), and shortcuts (Ctrl as the modifier in place
  of Cmd)
- Clipboard sync both ways

### Changes
1. Rendering. minifb's POSIX (Linux) scaler mishandles `AspectRatioStretch` when
   the buffer is taller than the window: it swaps width/height into
   `image_resize_linear_stride`, shearing the picture and squashing it into the
   top of the window. The frame is now pre-letterboxed into a window-sized buffer
   and presented with plain `Stretch` (a 1:1 blit). This is shared code, so it
   also changes the macOS path; see the macOS note below.
2. Keyboard and shortcuts (non-macOS only). Text goes through minifb's input
   callback, with Ctrl tracked via `set_key_state` so a shortcut like Ctrl+C
   isn't also typed (the X11 and Wayland backends disagree on whether Ctrl+letter
   yields a control code or the bare letter). Esc/Enter/Tab/Backspace/arrows plus
   the Ctrl+J/L/T/R system actions and Ctrl+A/C/V/X/Z editing shortcuts mirror the
   macOS event monitor.
3. Clipboard (non-macOS only). The non-macOS clipboard functions were stubs;
   implemented with `arboard` (text only, X11 and Wayland). arboard has no change
   counter like NSPasteboard, so one is synthesized from a content hash to feed
   the existing poll and echo-suppression logic without a sync loop.

### Dependencies
- `arboard` (target-gated to non-macOS only; `default-features = false` plus
  `wayland-data-control`)

### Tested on
Host: Debian, KDE/Wayland.

Device:

| layout | device | iOS | injection |
| --- | --- | --- | --- |
| roothide | iPhone11,2 | 15.5 | ElleKit |

### Notes
- macOS rendering: the rendering change moves the letterboxing out of minifb's
  `AspectRatioStretch` and into a window-sized buffer presented with plain
  `Stretch`. On Linux this fixes a real shear bug. On macOS the same `Stretch`
  path maps the window-sized buffer 1:1 through the native Metal renderer, which I
  expect to match the previous output, but I have no macOS machine to test on. So
  this could be a breaking change on macOS and should be verified there before
  merging.
- Same external requirement as macOS: libimobiledevice tools (`iproxy`,
  `idevice_id`, `ideviceinfo`).
- `Ctrl+R` (Rotate) is wired on the host, but the device daemon doesn't implement
  the Rotate/Screenshot system actions yet, so it's currently a no-op (same as on
  macOS).
