### PR TITLE
fix: stabilize streaming on fragile iPhone 6s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ device/**/*.deb
 
 # Generated Sileo/Zebra repo output
 packaging/repo/out/
+dist/
 
 # macOS
 .DS_Store

--- a/device/daemon/ControlServer.mm
+++ b/device/daemon/ControlServer.mm
@@ -174,42 +174,41 @@ NSString *const IOSPYDaemonVersion = @"0.1.0";
                     BOOL h264 = (codec == IOSPY_VIDEO_CODEC_H264);
                     streaming = YES;
                     [[IOSPYFrameIngest shared] setVideoReliable:h264];
-                    [[IOSPYFrameIngest shared] tellTweakStartCodec:codec];
+                    [[IOSPYFrameIngest shared] tellTweakStartPayload:payload];
                     NSLog(@"[ioscpyd] stream started (codec=%s)", h264 ? "h264" : "mjpeg");
-                    if (!h264) {
-                        // MJPEG: latest-only pump that drops stale frames under
-                        // backpressure so motion stays smooth. H.264 goes out in
-                        // order straight from the ingest thread instead.
-                        pumpDone = dispatch_semaphore_create(0);
-                        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-                            uint64_t lastSeq = 0;
-                            while (alive && streaming) {
-                                // Drain the frame payloads each iteration so memory
-                                // doesn't climb on this long-lived block, or jetsam
-                                // kills the daemon.
-                                @autoreleasepool {
-                                    // Blocks until a new frame is ready, or a short
-                                    // timeout so we can re-check the run state.
-                                    NSData *frame =
-                                        [[IOSPYFrameStore shared] payloadNewerThan:&lastSeq];
-                                    if (!frame) {
-                                        continue;
-                                    }
-                                    [writeLock lock];
-                                    // Non-blocking: if the host is behind, this
-                                    // frame is dropped (rc == 0) and the loop grabs
-                                    // the newest next, so latency stays about a frame.
-                                    int rc = IOSPYTryWriteFrame(fd, IOSPYMsgVideoFrame,
-                                                                IOSPY_CHANNEL_VIDEO, lastSeq, frame);
-                                    [writeLock unlock];
-                                    if (rc < 0) {
-                                        break;
-                                    }
+                    // MJPEG/latest-only pump. Native MJPEG streams use it
+                    // directly; if H.264 later falls back to MJPEG, FrameIngest
+                    // routes those actual JPEG frames here too. Actual H.264
+                    // frames still go out in order straight from the ingest thread.
+                    pumpDone = dispatch_semaphore_create(0);
+                    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+                        uint64_t lastSeq = [[IOSPYFrameStore shared] currentSequence];
+                        while (alive && streaming) {
+                            // Drain the frame payloads each iteration so memory
+                            // doesn't climb on this long-lived block, or jetsam
+                            // kills the daemon.
+                            @autoreleasepool {
+                                // Blocks until a new frame is ready, or a short
+                                // timeout so we can re-check the run state.
+                                NSData *frame = [[IOSPYFrameStore shared] payloadNewerThan:&lastSeq];
+                                if (!frame) {
+                                    continue;
+                                }
+                                [writeLock lock];
+                                // Non-blocking: if the host is behind, this frame
+                                // is dropped (rc == 0) and the loop grabs the newest
+                                // next, so latency stays about a frame.
+                                int rc = IOSPYTryWriteFrame(fd, IOSPYMsgVideoFrame,
+                                                            IOSPY_CHANNEL_VIDEO, lastSeq, frame);
+                                [writeLock unlock];
+                                if (rc < 0) {
+                                    NSLog(@"[ioscpyd] latest-frame video write failed");
+                                    break;
                                 }
                             }
-                            dispatch_semaphore_signal(pumpDone);
-                        });
-                    }
+                        }
+                        dispatch_semaphore_signal(pumpDone);
+                    });
                 }
                 break;
             case IOSPYMsgStopStream:

--- a/device/daemon/FrameIngest.h
+++ b/device/daemon/FrameIngest.h
@@ -14,13 +14,14 @@
 // Whether a tweak is currently connected and able to stream.
 - (BOOL)tweakConnected;
 
-// Tell the tweak to begin capturing with a codec (0 = MJPEG, 1 = H.264) / stop.
-- (void)tellTweakStartCodec:(uint8_t)codec;
+// Tell the tweak to begin capturing with a START_STREAM payload / stop.
+- (void)tellTweakStartPayload:(NSData *)payload;
 - (void)tellTweakStop;
 
 // Choose how incoming video frames reach the host. MJPEG (NO) keeps only the
-// latest frame and drops under backpressure. H.264 (YES) forwards every frame in
-// order so the inter-frame stream stays intact.
+// latest frame and drops under backpressure. H.264 (YES) forwards actual H.264
+// frames in order so the inter-frame stream stays intact; actual MJPEG fallback
+// frames are still sent non-blocking/droppable.
 - (void)setVideoReliable:(BOOL)reliable;
 
 // Forward a control frame (e.g. input/system action) to the tweak.

--- a/device/daemon/FrameIngest.mm
+++ b/device/daemon/FrameIngest.mm
@@ -9,6 +9,16 @@
 #import <unistd.h>
 #import <errno.h>
 
+static BOOL IOSPYVideoPayloadIsH264(NSData *payload) {
+    if (payload.length < 16) {
+        return NO;
+    }
+    const uint8_t *bytes = (const uint8_t *)payload.bytes;
+    uint32_t flags = 0;
+    memcpy(&flags, bytes + 8, sizeof(flags));
+    return (ntohl(flags) & IOSPY_VIDEO_FLAG_H264) != 0;
+}
+
 @implementation IOSPYFrameIngest {
     uint16_t _port;
     int _listenFd;
@@ -16,7 +26,9 @@
     NSLock *_writeLock; // guards _tweakFd and writes to it
     int _hostFd;        // the control server's host socket, -1 when none
     NSLock *_hostLock;  // the control server's per-connection write lock
-    BOOL _videoReliable; // YES while an H.264 stream needs in-order delivery
+    BOOL _videoReliable; // YES when the host requested H.264/in-order delivery
+    BOOL _loggedMJPEGFallback;
+    BOOL _loggedReliableVideoFailure;
 }
 
 + (instancetype)shared {
@@ -48,6 +60,8 @@
 - (void)setVideoReliable:(BOOL)reliable {
     @synchronized(self) {
         _videoReliable = reliable;
+        _loggedMJPEGFallback = NO;
+        _loggedReliableVideoFailure = NO;
     }
 }
 
@@ -119,11 +133,12 @@
                 break;
             }
             if (header.type == IOSPYMsgVideoFrame && payload.length > 0) {
-                BOOL reliable;
+                BOOL requestedReliable;
                 @synchronized(self) {
-                    reliable = _videoReliable;
+                    requestedReliable = _videoReliable;
                 }
-                if (reliable) {
+                BOOL actualH264 = IOSPYVideoPayloadIsH264(payload);
+                if (requestedReliable && actualH264) {
                     // H.264: send every frame to the host in order. A blocking
                     // write backpressures the tweak's encoder instead of dropping
                     // a frame, which would corrupt the inter-frame stream.
@@ -143,9 +158,39 @@
                     }
                     if (hostFd >= 0 && hostLock) {
                         [hostLock lock];
-                        IOSPYWriteFrame(hostFd, IOSPYMsgVideoFrame, IOSPY_CHANNEL_VIDEO, 0, payload);
+                        BOOL ok = IOSPYWriteFrame(hostFd, IOSPYMsgVideoFrame,
+                                                 IOSPY_CHANNEL_VIDEO, 0, payload);
                         [hostLock unlock];
+                        if (!ok) {
+                            BOOL shouldLog = NO;
+                            @synchronized(self) {
+                                if (!_loggedReliableVideoFailure) {
+                                    _loggedReliableVideoFailure = YES;
+                                    shouldLog = YES;
+                                }
+                            }
+                            if (shouldLog) {
+                                NSLog(@"[ioscpyd] reliable H.264 video write failed");
+                            }
+                        }
                     }
+                } else if (requestedReliable) {
+                    // The host asked for H.264, but the tweak fell back to MJPEG
+                    // (JPEG frames have no H.264 flag). Do not run these large
+                    // frames through the reliable/blocking H.264 path. Put them
+                    // into the latest-frame store; the pump forwards them
+                    // non-blocking/droppable just like a native MJPEG stream.
+                    BOOL shouldLog = NO;
+                    @synchronized(self) {
+                        if (!_loggedMJPEGFallback) {
+                            _loggedMJPEGFallback = YES;
+                            shouldLog = YES;
+                        }
+                    }
+                    if (shouldLog) {
+                        NSLog(@"[ioscpyd] H.264 request is producing MJPEG; using latest-frame forwarding");
+                    }
+                    [[IOSPYFrameStore shared] setPayload:payload];
                 } else {
                     // MJPEG: keep only the latest frame, the pump drops stale ones.
                     [[IOSPYFrameStore shared] setPayload:payload];
@@ -179,11 +224,10 @@
     return connected;
 }
 
-- (void)tellTweakStartCodec:(uint8_t)codec {
+- (void)tellTweakStartPayload:(NSData *)payload {
     [_writeLock lock];
     if (_tweakFd >= 0) {
-        NSData *p = [NSData dataWithBytes:&codec length:1];
-        IOSPYWriteFrame(_tweakFd, IOSPYMsgStartStream, IOSPY_CHANNEL_CONTROL, 0, p);
+        IOSPYWriteFrame(_tweakFd, IOSPYMsgStartStream, IOSPY_CHANNEL_CONTROL, 0, payload);
     }
     [_writeLock unlock];
 }

--- a/device/daemon/FrameStore.h
+++ b/device/daemon/FrameStore.h
@@ -15,4 +15,8 @@
 // otherwise return nil and leave *seq untouched.
 - (NSData *)payloadNewerThan:(uint64_t *)seq;
 
+// Snapshot the current sequence so a new pump waits for frames from this stream
+// instead of immediately replaying the previous stream's last MJPEG frame.
+- (uint64_t)currentSequence;
+
 @end

--- a/device/daemon/FrameStore.mm
+++ b/device/daemon/FrameStore.mm
@@ -48,4 +48,11 @@
     return result;
 }
 
+- (uint64_t)currentSequence {
+    [_cond lock];
+    uint64_t seq = _seq;
+    [_cond unlock];
+    return seq;
+}
+
 @end

--- a/device/daemon/Protocol.h
+++ b/device/daemon/Protocol.h
@@ -25,7 +25,11 @@
 #define IOSPY_VIDEO_ORIENT_SHIFT  3
 #define IOSPY_VIDEO_ORIENT_MASK   0x18u
 
-// START_STREAM codec selector (1-byte payload; empty payload also means MJPEG).
+// START_STREAM payload:
+//   byte 0: codec selector (0/empty = MJPEG, 1 = H.264)
+//   bytes 1-2: optional max capture dimension, big-endian u16 (0 = tweak default)
+//   byte 3: optional fps cap (0 = tweak default)
+//   byte 4: optional JPEG quality percent 1..100 (0 = tweak default)
 #define IOSPY_VIDEO_CODEC_MJPEG   0
 #define IOSPY_VIDEO_CODEC_H264    1
 

--- a/device/tweak/Capture.mm
+++ b/device/tweak/Capture.mm
@@ -266,7 +266,7 @@ NSData *IOSPYCaptureScreenJPEG(CGFloat maxDimension, CGFloat quality,
         double encodeStart = nowMs();
         NSMutableData *data = [NSMutableData data];
         CGImageDestinationRef dest =
-            CGImageDestinationCreateWithData((__bridge CFMutableDataRef)data, kUTTypeJPEG, 1, NULL);
+            CGImageDestinationCreateWithData((__bridge CFMutableDataRef)data, CFSTR("public.jpeg"), 1, NULL);
         BOOL ok = NO;
         if (dest) {
             NSDictionary *options = @{(__bridge id)kCGImageDestinationLossyCompressionQuality: @(quality)};

--- a/device/tweak/StreamClient.mm
+++ b/device/tweak/StreamClient.mm
@@ -15,9 +15,13 @@
 // Capture tuning. We aim high on rate and let the serial capture queue settle the
 // real fps to whatever the device can sustain. Longest side is capped for
 // bandwidth and CPU.
-static const CGFloat kMaxDimension = 1600.0;
-static const CGFloat kQuality = 0.72;
-static const NSTimeInterval kInterval = 1.0 / 45.0;
+static const CGFloat kDefaultMaxDimension = 1600.0;
+static const CGFloat kDefaultQuality = 0.72;
+static const NSTimeInterval kDefaultInterval = 1.0 / 45.0;
+static const uint16_t kMinMaxDimension = 320;
+static const uint16_t kMaxMaxDimension = 1600;
+static const uint8_t kMinFps = 1;
+static const uint8_t kMaxFps = 60;
 
 // clipboard sync bookkeeping (must hash byte-identically to the host)
 static uint64_t gLastSyncedHash = 0;
@@ -36,6 +40,33 @@ static uint64_t clipHash(NSString *t) {
     return h;
 }
 
+static uint16_t readBE16(const uint8_t *bytes) {
+    return (uint16_t)(((uint16_t)bytes[0] << 8) | bytes[1]);
+}
+
+static CGFloat streamMaxDimension(uint16_t requested) {
+    if (requested == 0) {
+        return kDefaultMaxDimension;
+    }
+    return (CGFloat)MIN(MAX(requested, kMinMaxDimension), kMaxMaxDimension);
+}
+
+static NSTimeInterval streamInterval(uint8_t requestedFps) {
+    if (requestedFps == 0) {
+        return kDefaultInterval;
+    }
+    uint8_t fps = MIN(MAX(requestedFps, kMinFps), kMaxFps);
+    return 1.0 / (NSTimeInterval)fps;
+}
+
+static CGFloat streamQuality(uint8_t requestedPercent) {
+    if (requestedPercent == 0) {
+        return kDefaultQuality;
+    }
+    uint8_t percent = MIN(MAX(requestedPercent, 1), 100);
+    return (CGFloat)percent / 100.0;
+}
+
 @interface IOSPYStreamClient ()
 - (void)startClipboardObserver;
 - (void)checkClipboard;
@@ -51,6 +82,9 @@ static uint64_t clipHash(NSString *t) {
     dispatch_source_t _clipTimer;
     IOSPYH264Encoder *_encoder;    // created lazily on the capture queue
     uint8_t _codec;                // 0 = MJPEG, 1 = H.264 (host's request)
+    CGFloat _maxDimension;
+    CGFloat _quality;
+    NSTimeInterval _interval;
     BOOL _needKeyframe;            // force an H.264 keyframe on the next frame
 }
 
@@ -66,6 +100,9 @@ static uint64_t clipHash(NSString *t) {
 - (instancetype)init {
     if ((self = [super init])) {
         _fd = -1;
+        _maxDimension = kDefaultMaxDimension;
+        _quality = kDefaultQuality;
+        _interval = kDefaultInterval;
         _captureQueue = dispatch_queue_create("com.ioscpy.capture", DISPATCH_QUEUE_SERIAL);
         _clipQueue = dispatch_queue_create("com.ioscpy.clip", DISPATCH_QUEUE_SERIAL);
         [self startClipboardObserver];
@@ -204,12 +241,22 @@ static uint64_t clipHash(NSString *t) {
             continue;
         }
         if (header.type == IOSPYMsgStartStream) {
-            // The start command carries the codec the host wants (0/empty = MJPEG,
-            // 1 = H.264). Force a keyframe so a freshly connected host can decode.
-            uint8_t codec = (payload.length >= 1) ? ((const uint8_t *)payload.bytes)[0] : 0;
+            // START_STREAM: byte 0 selects codec. Newer hosts may append capture
+            // knobs: maxDimension u16, fps u8, JPEG quality percent u8. Missing or
+            // zero values keep the legacy defaults for backward compatibility.
+            const uint8_t *bytes = (const uint8_t *)payload.bytes;
+            uint8_t codec = (payload.length >= 1) ? bytes[0] : 0;
+            uint16_t maxDim = (payload.length >= 3) ? readBE16(bytes + 1) : 0;
+            uint8_t fps = (payload.length >= 4) ? bytes[3] : 0;
+            uint8_t quality = (payload.length >= 5) ? bytes[4] : 0;
             dispatch_async(_captureQueue, ^{
                 self->_codec = codec;
+                self->_maxDimension = streamMaxDimension(maxDim);
+                self->_interval = streamInterval(fps);
+                self->_quality = streamQuality(quality);
                 self->_needKeyframe = YES;
+                NSLog(@"[ioscpyhook] stream profile codec=%u max=%.0f fps=%.1f quality=%.2f",
+                      codec, self->_maxDimension, 1.0 / self->_interval, self->_quality);
                 [self startCapture];
             });
         } else if (header.type == IOSPYMsgStopStream) {
@@ -274,7 +321,10 @@ static uint64_t clipHash(NSString *t) {
         return;
     }
     _timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _captureQueue);
-    uint64_t interval = (uint64_t)(kInterval * NSEC_PER_SEC);
+    uint64_t interval = (uint64_t)(_interval * NSEC_PER_SEC);
+    if (interval == 0) {
+        interval = (uint64_t)(kDefaultInterval * NSEC_PER_SEC);
+    }
     dispatch_source_set_timer(_timer, DISPATCH_TIME_NOW, interval, interval / 4);
     __weak typeof(self) weakSelf = self;
     dispatch_source_set_event_handler(_timer, ^{ [weakSelf captureAndSend]; });
@@ -338,7 +388,7 @@ static NSData *makeVideoFrame(int width, int height, uint32_t flags, NSData *dat
 
 - (void)captureAndSendJPEG:(int)fd {
     int width = 0, height = 0;
-    NSData *jpeg = IOSPYCaptureScreenJPEG(kMaxDimension, kQuality, &width, &height, NULL, NULL);
+    NSData *jpeg = IOSPYCaptureScreenJPEG(_maxDimension, _quality, &width, &height, NULL, NULL);
     if (!jpeg) {
         return;
     }
@@ -354,11 +404,11 @@ static NSData *makeVideoFrame(int width, int height, uint32_t flags, NSData *dat
         _encoder = [[IOSPYH264Encoder alloc] init];
     }
     int width = 0, height = 0;
-    IOSurfaceRef surface = IOSPYCaptureScreenSurface(kMaxDimension, &width, &height);
+    IOSurfaceRef surface = IOSPYCaptureScreenSurface(_maxDimension, &width, &height);
     if (!surface || width < 2 || height < 2) {
         return NO;
     }
-    int fps = (int)round(1.0 / kInterval);
+    int fps = (int)round(1.0 / _interval);
     if (fps < 1) {
         fps = 1;
     }

--- a/device/tweak/Tweak.xm
+++ b/device/tweak/Tweak.xm
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
+#import <signal.h>
 
 #import "StreamClient.h"
 #import "InputInjector.h"
@@ -57,6 +58,10 @@ static BOOL gSuppressPasteAlert = NO;
 
 %ctor {
     @autoreleasepool {
+        // SpringBoard must not die if the daemon/host side closes a socket while
+        // the tweak is writing a frame or clipboard update.
+        signal(SIGPIPE, SIG_IGN);
+
         NSString *process = [[NSProcessInfo processInfo] processName];
         NSLog(@"[ioscpyhook] loaded into %@ (v0.1.0)", process);
 

--- a/host/src/cli.rs
+++ b/host/src/cli.rs
@@ -30,6 +30,10 @@ pub struct Cli {
     #[arg(long)]
     pub mjpeg: bool,
 
+    /// Force H.264, bypassing conservative device defaults (debugging only).
+    #[arg(long, hide = true, conflicts_with = "mjpeg")]
+    pub h264: bool,
+
     /// Hide the on-screen iOS keyboard while connected, so the mirror shows the
     /// full screen (you type from the Mac; the device acts as if a hardware
     /// keyboard is attached). The keyboard returns when ioscpy exits. iOS 16+.
@@ -73,5 +77,29 @@ pub struct Cli {
 impl Cli {
     pub fn parse_args() -> Self {
         Cli::parse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    #[test]
+    fn hidden_h264_override_parses_but_stays_out_of_help() {
+        let cli = Cli::try_parse_from(["ioscpy", "--h264"]).unwrap();
+        assert!(cli.h264);
+        assert!(!cli.mjpeg);
+
+        let mut cmd = Cli::command();
+        let help = cmd.render_long_help().to_string();
+        assert!(!help.contains("--h264"));
+        assert!(help.contains("--mjpeg"));
+    }
+
+    #[test]
+    fn h264_override_conflicts_with_mjpeg() {
+        let err = Cli::try_parse_from(["ioscpy", "--h264", "--mjpeg"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 }

--- a/host/src/codec.rs
+++ b/host/src/codec.rs
@@ -1,0 +1,220 @@
+//! Host-side stream codec selection.
+//!
+//! The daemon advertises what it can stream, but some device/OS combinations are
+//! known to be fragile when H.264 is requested. Keep that policy here so the
+//! session, bench, and tests all agree on the same default.
+
+use crate::protocol::{self, Capabilities};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodecPreference {
+    Auto,
+    Mjpeg,
+    H264,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodecChoiceReason {
+    ExplicitMjpeg,
+    ExplicitH264,
+    FragileDeviceDefault,
+    H264Advertised,
+    H264Unavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CodecChoice {
+    pub codec: u8,
+    pub reason: CodecChoiceReason,
+    pub profile: StreamProfile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamProfile {
+    pub max_dimension: u16,
+    pub fps: u8,
+    pub quality_percent: u8,
+}
+
+impl StreamProfile {
+    const DEFAULT: Self = Self {
+        max_dimension: 0,
+        fps: 0,
+        quality_percent: 0,
+    };
+
+    const FRAGILE_IPHONE_6S: Self = Self {
+        max_dimension: 960,
+        fps: 12,
+        quality_percent: 55,
+    };
+}
+
+pub fn choose_stream_codec(caps: &Capabilities, preference: CodecPreference) -> CodecChoice {
+    match preference {
+        CodecPreference::Mjpeg => CodecChoice {
+            codec: protocol::VIDEO_CODEC_MJPEG,
+            reason: CodecChoiceReason::ExplicitMjpeg,
+            profile: StreamProfile::DEFAULT,
+        },
+        CodecPreference::H264 => CodecChoice {
+            codec: protocol::VIDEO_CODEC_H264,
+            reason: CodecChoiceReason::ExplicitH264,
+            profile: StreamProfile::DEFAULT,
+        },
+        CodecPreference::Auto if !supports_h264(caps) => CodecChoice {
+            codec: protocol::VIDEO_CODEC_MJPEG,
+            reason: CodecChoiceReason::H264Unavailable,
+            profile: StreamProfile::DEFAULT,
+        },
+        CodecPreference::Auto if has_fragile_h264_default(caps) => CodecChoice {
+            codec: protocol::VIDEO_CODEC_MJPEG,
+            reason: CodecChoiceReason::FragileDeviceDefault,
+            profile: StreamProfile::FRAGILE_IPHONE_6S,
+        },
+        CodecPreference::Auto => CodecChoice {
+            codec: protocol::VIDEO_CODEC_H264,
+            reason: CodecChoiceReason::H264Advertised,
+            profile: StreamProfile::DEFAULT,
+        },
+    }
+}
+
+pub fn start_stream_payload(choice: CodecChoice) -> Vec<u8> {
+    if choice.profile == StreamProfile::DEFAULT {
+        return vec![choice.codec];
+    }
+    let mut payload = Vec::with_capacity(5);
+    payload.push(choice.codec);
+    payload.extend_from_slice(&choice.profile.max_dimension.to_be_bytes());
+    payload.push(choice.profile.fps);
+    payload.push(choice.profile.quality_percent);
+    payload
+}
+
+pub fn codec_name(codec: u8) -> &'static str {
+    match codec {
+        protocol::VIDEO_CODEC_H264 => "h264",
+        _ => "mjpeg",
+    }
+}
+
+fn supports_h264(caps: &Capabilities) -> bool {
+    caps.stream_backends
+        .iter()
+        .any(|backend| backend.eq_ignore_ascii_case("h264"))
+}
+
+fn has_fragile_h264_default(caps: &Capabilities) -> bool {
+    // iPhone 6s on iOS 15.x has been observed dropping USB/usbmux enumeration
+    // when the host requests H.264. Keep the automatic path conservative while
+    // still letting advanced users opt in with the hidden --h264 switch.
+    matches!(
+        (caps.device_model.trim(), ios_major(&caps.ios_version)),
+        ("iPhone8,1", Some(15))
+    )
+}
+
+fn ios_major(version: &str) -> Option<u16> {
+    version
+        .trim()
+        .split('.')
+        .next()
+        .and_then(|major| major.parse::<u16>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn caps(device_model: &str, ios_version: &str, stream_backends: &[&str]) -> Capabilities {
+        Capabilities {
+            ios_version: ios_version.to_string(),
+            device_model: device_model.to_string(),
+            jailbreak_layout: String::new(),
+            jb_prefix: String::new(),
+            injection_framework: String::new(),
+            daemon_uid: 0,
+            stream_backends: stream_backends.iter().map(|s| s.to_string()).collect(),
+            input_backends: Vec::new(),
+            clipboard: false,
+            keyboard: false,
+            orientation: false,
+        }
+    }
+
+    #[test]
+    fn fragile_iphone81_ios15_defaults_to_mjpeg() {
+        let choice = choose_stream_codec(
+            &caps("iPhone8,1", "15.8.8", &["h264", "mjpeg"]),
+            CodecPreference::Auto,
+        );
+
+        assert_eq!(choice.codec, protocol::VIDEO_CODEC_MJPEG);
+        assert_eq!(choice.reason, CodecChoiceReason::FragileDeviceDefault);
+        assert_eq!(
+            choice.profile,
+            StreamProfile {
+                max_dimension: 960,
+                fps: 12,
+                quality_percent: 55,
+            }
+        );
+        assert_eq!(start_stream_payload(choice), vec![0, 0x03, 0xc0, 12, 55]);
+    }
+
+    #[test]
+    fn iphone81_outside_ios15_still_defaults_to_h264_when_advertised() {
+        let choice = choose_stream_codec(
+            &caps("iPhone8,1", "14.8.1", &["h264", "mjpeg"]),
+            CodecPreference::Auto,
+        );
+
+        assert_eq!(choice.codec, protocol::VIDEO_CODEC_H264);
+        assert_eq!(choice.reason, CodecChoiceReason::H264Advertised);
+    }
+
+    #[test]
+    fn fragile_iphone81_ios15_can_explicitly_request_h264() {
+        let choice = choose_stream_codec(
+            &caps("iPhone8,1", "15.8.8", &["h264", "mjpeg"]),
+            CodecPreference::H264,
+        );
+
+        assert_eq!(choice.codec, protocol::VIDEO_CODEC_H264);
+        assert_eq!(choice.reason, CodecChoiceReason::ExplicitH264);
+    }
+
+    #[test]
+    fn normal_h264_capable_device_defaults_to_h264() {
+        let choice = choose_stream_codec(
+            &caps("iPhone14,2", "17.5.1", &["h264", "mjpeg"]),
+            CodecPreference::Auto,
+        );
+
+        assert_eq!(choice.codec, protocol::VIDEO_CODEC_H264);
+        assert_eq!(choice.reason, CodecChoiceReason::H264Advertised);
+    }
+
+    #[test]
+    fn explicit_mjpeg_wins_on_h264_capable_device() {
+        let choice = choose_stream_codec(
+            &caps("iPhone14,2", "17.5.1", &["h264", "mjpeg"]),
+            CodecPreference::Mjpeg,
+        );
+
+        assert_eq!(choice.codec, protocol::VIDEO_CODEC_MJPEG);
+        assert_eq!(choice.reason, CodecChoiceReason::ExplicitMjpeg);
+    }
+
+    #[test]
+    fn h264_unavailable_defaults_to_mjpeg() {
+        let choice = choose_stream_codec(
+            &caps("iPhone14,2", "17.5.1", &["mjpeg"]),
+            CodecPreference::Auto,
+        );
+
+        assert_eq!(choice.codec, protocol::VIDEO_CODEC_MJPEG);
+        assert_eq!(choice.reason, CodecChoiceReason::H264Unavailable);
+    }
+}

--- a/host/src/health.rs
+++ b/host/src/health.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 
+use crate::codec::CodecChoice;
 use crate::h264::{Decoded, H264Decoder};
 use crate::input::InputFrame;
 use crate::protocol::{self, Capabilities, HelloAck, LogMessage, MessageType, CHANNEL_CONTROL};
@@ -66,7 +67,7 @@ pub fn run_session(
     frame_sink: Option<FrameSlot>,
     input_rx: Option<&Receiver<InputFrame>>,
     clip_in: Option<&Sender<String>>,
-    codec: u8,
+    codec_choice: CodecChoice,
     suppress_keyboard: bool,
 ) -> Result<SessionEnd> {
     stream.set_read_timeout(None).ok();
@@ -74,14 +75,15 @@ pub fn run_session(
     let mut reader = stream.try_clone().context("clone control stream")?;
 
     // Ask the daemon to start streaming once we have somewhere to show it. The
-    // one-byte payload picks the codec.
+    // payload starts with the codec and may carry conservative capture knobs for
+    // device/OS combinations that are unstable under the legacy 1600px/45fps path.
     if frame_sink.is_some() {
         let _ = protocol::write_frame(
             &mut writer,
             MessageType::StartStream,
             CHANNEL_CONTROL,
             0,
-            &[codec],
+            &crate::codec::start_stream_payload(codec_choice),
         );
     }
 
@@ -109,6 +111,7 @@ pub fn run_session(
     let sink = frame_sink.clone();
     let reader_count = video_count.clone();
     let reader_keyframe = want_keyframe.clone();
+    let reader_stop = stop.clone();
     let reader_handle = thread::spawn(move || {
         // H.264 is stateful, so we decode here, in order, as frames arrive (can't
         // keep latest and decode later). The decoder is built on the first H.264
@@ -157,8 +160,10 @@ pub fn run_session(
                     }
                 }
                 Err(e) => {
-                    crate::warn!("reader stopped: {e}");
-                    let _ = tx.send(Incoming::Disconnected);
+                    if !reader_stop.load(Ordering::Relaxed) {
+                        crate::warn!("reader stopped: {e}");
+                        let _ = tx.send(Incoming::Disconnected);
+                    }
                     break;
                 }
             }
@@ -197,7 +202,15 @@ pub fn run_session(
             }
         }
 
-        if last_ping.elapsed() >= ping_every {
+        // Video frames are already a high-frequency liveness signal. While they
+        // are flowing, avoid extra ping/pong writes on the control stream; older
+        // usbmux/device combinations have proven sensitive to needless duplex
+        // control traffic during capture startup.
+        let video_recent = streaming && last_video_progress.elapsed() <= ping_every;
+        if video_recent {
+            last_pong = Instant::now();
+        }
+        if !video_recent && last_ping.elapsed() >= ping_every {
             if protocol::write_frame(&mut writer, MessageType::Ping, CHANNEL_CONTROL, seq, &[])
                 .is_err()
             {
@@ -275,6 +288,20 @@ pub fn run_session(
             break SessionEnd::Lost;
         }
     };
+
+    // Stop capture before tearing down the USB control socket. On older devices,
+    // closing the socket while SpringBoard is still pushing frames can destabilize
+    // usbmux/lockdown; bench/snapshot already stop explicitly, so do the same for
+    // the live session loop.
+    if streaming {
+        let _ = protocol::write_frame(
+            &mut writer,
+            MessageType::StopStream,
+            CHANNEL_CONTROL,
+            0,
+            &[],
+        );
+    }
 
     // Restore the device keyboard if we hid it. Best-effort: the device also
     // restores on disconnect, so a failed write here is harmless.

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -6,6 +6,7 @@
 
 mod cli;
 mod clipboard;
+mod codec;
 mod config;
 mod device;
 mod h264;
@@ -233,13 +234,12 @@ fn run_connection_loop(
             info!("session live. Press Ctrl-C to quit");
         }
 
-        // Use H.264 when the device offers it and the user didn't force MJPEG.
-        // The daemon also falls back to MJPEG if it can't honor the request.
-        let codec = if !cli.mjpeg && ack.capabilities.stream_backends.iter().any(|b| b == "h264") {
-            protocol::VIDEO_CODEC_H264
-        } else {
-            protocol::VIDEO_CODEC_MJPEG
-        };
+        let codec_choice = choose_stream_codec(cli, &ack.capabilities);
+        debug!(
+            "requesting {} stream ({:?})",
+            codec::codec_name(codec_choice.codec),
+            codec_choice.reason
+        );
 
         // Only hide the device keyboard if asked and the tweak can do it.
         let suppress_keyboard = cli.no_keyboard && ack.capabilities.keyboard;
@@ -250,7 +250,7 @@ fn run_connection_loop(
             frame_sink.clone(),
             input_rx.as_ref(),
             clip_in.as_ref(),
-            codec,
+            codec_choice,
             suppress_keyboard,
         )? {
             health::SessionEnd::Quit => break,
@@ -325,25 +325,17 @@ fn cmd_bench(cli: &Cli, port: u16, secs: u64) -> Result<()> {
     if ack.capabilities.stream_backends.is_empty() {
         warn!("the phone side isn't fully up yet, so the screen might not show. Respring the phone (or reinstall ioscpy from Sileo) and reconnect.");
     }
-    let codec = if !cli.mjpeg && ack.capabilities.stream_backends.iter().any(|b| b == "h264") {
-        protocol::VIDEO_CODEC_H264
-    } else {
-        protocol::VIDEO_CODEC_MJPEG
-    };
+    let codec_choice = choose_stream_codec(cli, &ack.capabilities);
     println!(
         "bench: requesting {} stream",
-        if codec == protocol::VIDEO_CODEC_H264 {
-            "h264"
-        } else {
-            "mjpeg"
-        }
+        codec::codec_name(codec_choice.codec)
     );
     protocol::write_frame(
         &mut stream,
         protocol::MessageType::StartStream,
         protocol::CHANNEL_CONTROL,
         0,
-        &[codec],
+        &codec::start_stream_payload(codec_choice),
     )?;
     // Ask for a keyframe so H.264 decodes from the first frame.
     let _ = protocol::write_frame(
@@ -522,6 +514,18 @@ fn establish(
     let stream = forward.connect()?;
     *forward_slot = Some(forward);
     Ok(stream)
+}
+
+/// Map CLI codec flags to the shared host-side codec policy.
+fn choose_stream_codec(cli: &Cli, caps: &protocol::Capabilities) -> codec::CodecChoice {
+    let preference = if cli.mjpeg {
+        codec::CodecPreference::Mjpeg
+    } else if cli.h264 {
+        codec::CodecPreference::H264
+    } else {
+        codec::CodecPreference::Auto
+    };
+    codec::choose_stream_codec(caps, preference)
 }
 
 /// The protocol version must match. A different build version is just noted under

--- a/host/src/usbmux.rs
+++ b/host/src/usbmux.rs
@@ -4,9 +4,10 @@
 //! A native usbmux client could replace the `iproxy` child later, the API
 //! (`start` / `connect` / `local_port`) wouldn't change.
 
+use std::io::{BufRead, BufReader};
 use std::net::{TcpListener, TcpStream};
 use std::process::{Child, Command, Stdio};
-use std::thread::sleep;
+use std::thread::{self, sleep, JoinHandle};
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
@@ -14,6 +15,7 @@ use anyhow::{bail, Context, Result};
 /// A live USB port forward from a local TCP port to a device port over usbmux.
 pub struct UsbForward {
     child: Child,
+    stderr_log: Option<JoinHandle<()>>,
     pub local_port: u16,
     pub device_port: u16,
 }
@@ -44,15 +46,22 @@ impl UsbForward {
         let local_port = free_local_port()?;
         let pair = format!("{local_port}:{device_port}");
 
-        let mut child = Command::new("iproxy")
-            .arg(&pair)
+        let mut cmd = Command::new("iproxy");
+        cmd.arg(&pair)
             .arg("-u")
             .arg(udid)
             .arg("-l") // USB device only, never network
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stdout(Stdio::null());
+        if crate::logging::debug_enabled() {
+            cmd.stderr(Stdio::piped());
+        } else {
+            cmd.stderr(Stdio::null());
+        }
+
+        let mut child = cmd
             .spawn()
             .context("couldn't start the USB link. The USB tools are missing. Install them with:  brew install libimobiledevice")?;
+        let stderr_log = spawn_stderr_logger(&mut child, &pair);
 
         let deadline = Instant::now() + Duration::from_secs(6);
         loop {
@@ -71,6 +80,7 @@ impl UsbForward {
 
         Ok(Self {
             child,
+            stderr_log,
             local_port,
             device_port,
         })
@@ -85,10 +95,35 @@ impl UsbForward {
     }
 }
 
+fn spawn_stderr_logger(child: &mut Child, pair: &str) -> Option<JoinHandle<()>> {
+    let stderr = child.stderr.take()?;
+    let pair = pair.to_string();
+    Some(thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    let line = line.trim_end();
+                    if !line.is_empty() {
+                        crate::debug!("iproxy[{pair}] stderr: {line}");
+                    }
+                }
+                Err(e) => {
+                    crate::debug!("iproxy[{pair}] stderr read failed: {e}");
+                    break;
+                }
+            }
+        }
+    }))
+}
+
 impl Drop for UsbForward {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+        if let Some(stderr_log) = self.stderr_log.take() {
+            let _ = stderr_log.join();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- default known-fragile `iPhone8,1` devices on iOS 15.x to MJPEG instead of H.264 unless `--h264` is explicitly requested
- send conservative stream profile for that combo: 960px max dimension, 12 fps, 55% JPEG quality
- extend START_STREAM payload in a backward-compatible way and pass it daemon → tweak
- avoid keepalive ping/pong traffic while video frames are flowing
- send STOP_STREAM before live-session teardown so SpringBoard stops capture before usbmux/socket shutdown
- add hidden `--h264` diagnostic override and keep `--mjpeg` public behavior unchanged
- surface `iproxy` stderr when `--debug` is enabled
- route actual MJPEG fallback frames through the droppable latest-frame pump instead of the reliable H.264 path
- ignore SIGPIPE in the SpringBoard tweak so closed sockets do not kill SpringBoard
- fix Xcode 27 build compatibility by using `public.jpeg` directly instead of removed `kUTTypeJPEG`
- ignore generated `dist/` output

## Why
On an iPhone 6s (`iPhone8,1`) running iOS 15.8.8, `--handshake-only` was stable but starting the legacy high-rate stream could drop macOS usbmux/USB enumeration. Host-only MJPEG still reproduced the drop with the old device package. The stable path is lower-load MJPEG plus cleaner session shutdown.

## Test plan
- [x] `cd host && cargo fmt --check`
- [x] `cd host && cargo test` — 11 passed
- [x] `cd host && cargo clippy --all-targets --all-features` — exits 0, existing objc macro warnings remain
- [x] `cd host && cargo build --release`
- [x] `make device-rootless THEOS=/Volumes/Carve/Projects/_deps/theos TARGET=iphone:clang:latest:15.0`
- [x] installed rebuilt rootless `.deb` on real iPhone 6s over USB SSH using existing key auth
- [x] `ioscpyctl status`: iPhone8,1 / iOS 15.8.8 / roothide / ElleKit / daemon running / tweak installed
- [x] `ioscpy --list`: device visible
- [x] `ioscpy --debug --handshake-only`: succeeds
- [x] `ioscpy --debug --bench 8`: 97 MJPEG frames in 8.0s = 12.1 fps, 540x960, ~0.53 MB/s; USB still visible afterward
- [x] `ioscpy --debug --soak 35`: completes and reconnects once without dropping USB; USB still visible afterward
- [x] post-soak `ioscpy --debug --bench 5`: 61 MJPEG frames in 5.1s = 12.1 fps; USB still visible afterward

## Notes
The live soak currently logs one reader disconnect/reconnect during shutdown/loop teardown, but unlike the original failure the device remains enumerated and a follow-up bench succeeds. That is a huge practical improvement on the tested 6s; a follow-up could make the soak helper treat expected timer shutdown as a clean end without reconnecting.
