### PR TITLE
Linux H.264 support via openh264 + install fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ id_rsa*
 *.token
 secrets.env
 .env
+docs/linux-h264.md

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install-host:
 	    echo "host/target/release/ioscpy missing; run 'make host-release' as your user first"; \
 	    exit 1; \
 	}
-	install -m 0755 host/target/release/ioscpy $(PREFIX)/bin/ioscpy
+	install -D -m 0755 host/target/release/ioscpy $(PREFIX)/bin/ioscpy
 	@echo "installed ioscpy -> $(PREFIX)/bin/ioscpy"
 
 uninstall-host:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,14 @@ host:
 host-release:
 	cd host && cargo build --release
 
-install-host: host-release
+# No host-release dependency on purpose: this target is usually run with sudo,
+# and root's PATH does not see a rustup-installed cargo. Build as your user
+# first (`make host-release`), then install.
+install-host:
+	@test -x host/target/release/ioscpy || { \
+	    echo "host/target/release/ioscpy missing; run 'make host-release' as your user first"; \
+	    exit 1; \
+	}
 	install -m 0755 host/target/release/ioscpy $(PREFIX)/bin/ioscpy
 	@echo "installed ioscpy -> $(PREFIX)/bin/ioscpy"
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ install-host:
 	    echo "host/target/release/ioscpy missing; run 'make host-release' as your user first"; \
 	    exit 1; \
 	}
-	install -D -m 0755 host/target/release/ioscpy $(PREFIX)/bin/ioscpy
+	mkdir -p $(PREFIX)/bin
+	install -m 0755 host/target/release/ioscpy $(PREFIX)/bin/ioscpy
 	@echo "installed ioscpy -> $(PREFIX)/bin/ioscpy"
 
 uninstall-host:

--- a/README.md
+++ b/README.md
@@ -63,14 +63,53 @@ Rotating the phone rotates and resizes the mirror.
 
 ## Linux
 
+There is no prebuilt for Linux yet. Build the host from source. The device
+package is the same as on macOS, installed from the Sileo/Zebra repo above.
+
+Prereqs on Debian/Ubuntu:
+
+```bash
+sudo apt install build-essential pkg-config nasm \
+                 libimobiledevice-utils usbmuxd \
+                 libxkbcommon-dev libwayland-dev \
+                 libxcb1-dev libxkbcommon-x11-dev
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Make sure `usbmuxd` is running so the device shows up:
+
+```bash
+sudo systemctl enable --now usbmuxd
+idevice_id -l   # should print the UDID with the phone attached
+```
+
+Build the host as your user, then install:
+
+```bash
+make host-release
+sudo make install-host    # installs to /usr/local/bin/ioscpy
+ioscpy --version
+```
+
+The build step stays as your user so a rustup-installed `cargo` is found.
+`install-host` is a separate target that just copies the built binary, so it
+runs fine under `sudo` without needing `cargo` on root's PATH. For a no-sudo
+install in your home, use `make install-host PREFIX=$HOME/.local` and make
+sure `$HOME/.local/bin` is on your `PATH`.
+
+H.264 decoding works on Linux through the `openh264` software decoder. Pass
+`--mjpeg` if you prefer the MJPEG path.
+
 ## Tested on
-Host: Debian, KDE/Wayland.
+
+Hosts: Debian, KDE/Wayland; Ubuntu 26.04, GNOME/Wayland.
 
 Device:
 
 | layout | device | iOS | injection |
 | --- | --- | --- | --- |
 | roothide | iPhone11,2 | 15.5 | ElleKit |
+| roothide | iPhone10,4 | 16.7.12 | ElleKit |
 
 ## macOS
 

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -116,12 +116,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "cc"
 version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -473,13 +481,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -538,6 +558,7 @@ dependencies = [
  "ctrlc",
  "minifb",
  "objc",
+ "openh264",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -555,6 +576,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -670,6 +701,15 @@ dependencies = [
  "wayland-protocols 0.29.5",
  "winapi",
  "x11-dl",
+]
+
+[[package]]
+name = "nasm-rs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706bf8a5e8c8ddb99128c3291d31bd21f4bcde17f0f4c20ec678d85c74faa149"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -800,6 +840,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openh264"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a12b82c14f702c2cece4e0fc28896c6a6bed5317dc13448c86ac41df91a6f82"
+dependencies = [
+ "openh264-sys2",
+ "wide",
+]
+
+[[package]]
+name = "openh264-sys2"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9e072e9b270f3b291c80488dc160abc31ecc214ab3bfde937213cfd8c83b32"
+dependencies = [
+ "cc",
+ "nasm-rs",
+ "walkdir",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +968,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -953,6 +1020,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -1074,7 +1159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1148,6 +1233,25 @@ name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1358,6 +1462,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1486,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1467,6 +1590,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wl-clipboard-rs"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -33,8 +33,11 @@ cocoa = "0.25"
 
 # Host clipboard on Linux/Windows (macOS uses NSPasteboard directly). Text only,
 # so image-data is dropped; wayland-data-control adds Wayland alongside X11.
+# openh264 is the software H.264 decoder used off macOS, since the VideoToolbox
+# shim in h264_decoder.m is mac-only.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+openh264 = "0.9"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cc = "1"

--- a/host/src/h264.rs
+++ b/host/src/h264.rs
@@ -99,14 +99,70 @@ impl Drop for H264Decoder {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub struct H264Decoder;
+use openh264::{decoder::Decoder, formats::YUVSource};
+
+#[cfg(not(target_os = "macos"))]
+pub struct H264Decoder {
+    inner: Decoder,
+    // Reused between frames so the per-frame conversion is a copy, not an
+    // allocation.
+    annex_b: Vec<u8>,
+    rgb: Vec<u8>,
+}
+
+#[cfg(not(target_os = "macos"))]
+const H264_ANNEX_B_START: [u8; 4] = [0, 0, 0, 1];
+
+/// Convert one AVCC sample (4-byte big-endian length, then NAL, repeated) into
+/// the Annex-B form openh264 expects (start code, then NAL, repeated). Returns
+/// `false` if the lengths don't add up, which means a malformed frame.
+#[cfg(not(target_os = "macos"))]
+fn avcc_to_annex_b(avcc: &[u8], out: &mut Vec<u8>) -> bool {
+    out.clear();
+    let mut i = 0;
+    while i + 4 <= avcc.len() {
+        let nal_len = u32::from_be_bytes([avcc[i], avcc[i + 1], avcc[i + 2], avcc[i + 3]]) as usize;
+        i += 4;
+        if nal_len == 0 || i + nal_len > avcc.len() {
+            return false;
+        }
+        out.extend_from_slice(&H264_ANNEX_B_START);
+        out.extend_from_slice(&avcc[i..i + nal_len]);
+        i += nal_len;
+    }
+    i == avcc.len()
+}
 
 #[cfg(not(target_os = "macos"))]
 impl H264Decoder {
     pub fn new() -> Option<Self> {
-        None
+        Decoder::new().ok().map(|inner| Self {
+            inner,
+            annex_b: Vec::new(),
+            rgb: Vec::new(),
+        })
     }
-    pub fn decode(&mut self, _avcc: &[u8]) -> Decoded {
-        Decoded::Failed
+
+    pub fn decode(&mut self, avcc: &[u8]) -> Decoded {
+        if !avcc_to_annex_b(avcc, &mut self.annex_b) {
+            return Decoded::Failed;
+        }
+        match self.inner.decode(&self.annex_b) {
+            Ok(Some(yuv)) => {
+                let (width, height) = yuv.dimensions();
+                let needed = width * height * 3;
+                if self.rgb.len() < needed {
+                    self.rgb.resize(needed, 0);
+                }
+                yuv.write_rgb8(&mut self.rgb[..needed]);
+                let buf = crate::video::pack_rgb888(&self.rgb, width, height);
+                Decoded::Frame(DecodedFrame { buf, width, height })
+            }
+            Ok(None) => Decoded::Pending,
+            Err(e) => {
+                crate::warn!("h264 decode error: {e}");
+                Decoded::Failed
+            }
+        }
     }
 }

--- a/host/src/video.rs
+++ b/host/src/video.rs
@@ -73,8 +73,21 @@ pub fn rotate_cw(frame: DecodedFrame, turns: u8) -> DecodedFrame {
     }
 }
 
+/// Pack a tightly-packed RGB888 buffer into the window's `0x00RRGGBB` layout.
+/// `rgb.len()` must be at least `width * height * 3`; extra bytes are ignored.
+pub fn pack_rgb888(rgb: &[u8], width: usize, height: usize) -> Vec<u32> {
+    let mut buf = vec![0u32; width * height];
+    for (i, px) in buf.iter_mut().enumerate() {
+        let r = rgb[i * 3] as u32;
+        let g = rgb[i * 3 + 1] as u32;
+        let b = rgb[i * 3 + 2] as u32;
+        *px = (r << 16) | (g << 8) | b;
+    }
+    buf
+}
+
 /// Decode a JPEG into a packed 0RGB buffer. Returns `None` on a bad frame.
-/// Color JPEGs decode to RGB by default, which is what the packing below expects.
+/// Color JPEGs decode to RGB by default, which is what the packing expects.
 pub fn decode_jpeg(jpeg: &[u8]) -> Option<DecodedFrame> {
     let mut decoder = JpegDecoder::new(jpeg);
     let pixels = decoder.decode().ok()?;
@@ -84,12 +97,6 @@ pub fn decode_jpeg(jpeg: &[u8]) -> Option<DecodedFrame> {
         return None;
     }
 
-    let mut buf = vec![0u32; width * height];
-    for (i, px) in buf.iter_mut().enumerate() {
-        let r = pixels[i * 3] as u32;
-        let g = pixels[i * 3 + 1] as u32;
-        let b = pixels[i * 3 + 2] as u32;
-        *px = (r << 16) | (g << 8) | b;
-    }
+    let buf = pack_rgb888(&pixels, width, height);
     Some(DecodedFrame { buf, width, height })
 }


### PR DESCRIPTION
## Summary
- Linux H.264 decode via the `openh264` software decoder. Replaces the
  non-mac `H264Decoder` stub. Converts the device's AVCC frames to Annex-B
  and reuses the existing `0x00RRGGBB` `DecodedFrame` layout (new shared
  `pack_rgb888` helper, also called by `decode_jpeg`). Linux no longer
  needs `--mjpeg`.
- Fix `sudo make install-host` failing under rustup-installed cargo: drop
  the `host-release` prerequisite and add a missing-binary guard with a
  pointer to `make host-release`.
- README: Linux build-from-source instructions (apt deps incl. `nasm`,
  rustup, `usbmuxd`), updated install flow, drop the `--mjpeg` note,
  add Ubuntu 26.04 GNOME/Wayland host and iPhone10,4 iOS 16.7.12
  roothide/ElleKit device rows.

## Build effect
- New dep `openh264 = "0.9"` under `cfg(not(target_os = "macos"))`. Pulls
  `openh264-sys2`, which builds C++ + NASM, so Linux builds now need
  `nasm` (added to the README apt install line). macOS build path
  unchanged.
- Install flow is now two commands: `make host-release` as user, then
  `sudo make install-host`. The old single-command flow failed for anyone
  using a rustup-installed cargo because root's PATH did not see it.

## Tested
- Ubuntu 26.04 GNOME/Wayland host against iPhone10,4 iOS 16.7.12
  (roothide, ElleKit). H.264 stream renders, no `reader stopped` errors.
- macOS build path: unchanged (VideoToolbox shim still gated on
  `cfg(target_os = "macos")`).