### PR TITLE
Windows host support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ id_rsa*
 secrets.env
 .env
 docs/linux-h264.md
+docs/windows/

--- a/README.md
+++ b/README.md
@@ -51,26 +51,6 @@ ioscpy --debug           # full diagnostics
 ioscpy --version
 ```
 
-## First touch
-
-> After a respring or a fresh connection, give the phone one physical tap on its
-> screen before driving it from the Mac. iOS only trusts touch events that come
-> from the real digitizer, so that first real tap is what lets the injected ones
-> through. You do it once, then the Mac takes over.
-
-## Controls
-
-- Mouse: click to tap, click and drag to swipe.
-- Typing: keystrokes go to the focused field, in any Mac keyboard layout. Accents
-  and emoji go through the clipboard.
-- Esc: go back.
-- Cmd+J, Cmd+L, Cmd+T, Cmd+R: Home, Lock, App Switcher, Rotate.
-- Cmd+A, Cmd+C, Cmd+V, Cmd+X, Cmd+Z: Select All, Copy, Paste, Cut, Undo. The
-  clipboard syncs both ways, so Cmd+C on the phone reaches the Mac.
-- Enter, Backspace, Tab, arrows: the matching editing keys.
-
-Rotating the phone rotates and resizes the mirror.
-
 ## Linux
 
 There is no prebuilt for Linux yet. Build the host from source. The device
@@ -148,19 +128,16 @@ H.264 decoding works on Linux through the `openh264` software decoder. Pass
 
 ## Windows
 
-There is no prebuilt for Windows yet. Build the host from source. The device
-package is the same as on macOS and Linux, installed from the Sileo/Zebra repo.
+There is no prebuilt for Windows yet. Build the host from source. The device package is the same as on macOS and Linux, installed from the Sileo/Zebra repo.
 
-ioscpy on Windows reuses the USB tooling an iOS setup already has, and does **not**
-replace any driver, so Frida, objection, ideviceinfo, and iTunes keep working
-while it runs.
+ioscpy on Windows reuses the USB tooling an iOS setup already has, and does **not** replace any driver, so Frida, objection, ideviceinfo, and iTunes, grapefruit and any tool that uses it keep working while it runs.
 
-### 1. USB stack (talk to the iPhone)
+### 1. USB stack 
 
-- **Apple Mobile Device Support** — installed with iTunes from apple.com (get the
+- **Apple Mobile Device Support**  installed with iTunes from apple.com (get the
   Apple-website build, not the Microsoft Store one), or the standalone AMDS
   package. This provides the USB driver and usbmuxd. iTunes must see the phone.
-- **libimobiledevice-win32** — provides `iproxy.exe`, `idevice_id.exe`,
+- **libimobiledevice-win32**  provides `iproxy.exe`, `idevice_id.exe`,
   `ideviceinfo.exe`. Install with [Scoop](https://scoop.sh):
 
       scoop install libimobiledevice
@@ -169,15 +146,15 @@ while it runs.
 
       pacman -S mingw-w64-x86_64-libimobiledevice
 
-  Make sure the three `.exe`s are on your `PATH` (or drop them next to
-  `ioscpy.exe`). Check with `idevice_id -l` — it should print your device UDID.
+  Make sure the three `.exe` are on your `PATH` (or drop them next to
+  `ioscpy.exe`). Check with `idevice_id -l`  it should print your device UDID.
 
 ### 2. Build toolchain
 
-- **Rust** with the MSVC toolchain — install from [rustup.rs](https://rustup.rs).
+- **Rust** with the MSVC toolchain  install from [rustup.rs](https://rustup.rs).
 - **Visual Studio Build Tools** with the C++ workload (the `openh264` decoder
   compiles a small C library through `cc`).
-- **nasm** on `PATH` — `openh264`'s assembler (`scoop install nasm`).
+- **nasm** on `PATH`  `openh264`'s assembler (`scoop install nasm`).
 
 ### 3. Build and run
 
@@ -190,12 +167,33 @@ while it runs.
 Pass `--mjpeg` if you prefer the MJPEG path over H.264. If `openh264` fails to
 build, confirm `nasm` is on `PATH`.
 
+## First touch
+
+> After a respring or a fresh connection, give the phone one physical tap on its
+> screen before driving it from the Host. iOS only trusts touch events that come
+> from the real digitizer, so that first real tap is what lets the injected ones
+> through. You do it once, then the Host takes over.
+
+## Controls
+
+- Mouse: click to tap, click and drag to swipe.
+- Typing: keystrokes go to the focused field, in any Mac keyboard layout. Accents
+  and emoji go through the clipboard.
+- Esc: go back.
+- Cmd+J, Cmd+L, Cmd+T, Cmd+R: Home, Lock, App Switcher, Rotate.
+- Cmd+A, Cmd+C, Cmd+V, Cmd+X, Cmd+Z: Select All, Copy, Paste, Cut, Undo. The
+  clipboard syncs both ways, so Cmd+C on the phone reaches the Mac.
+- Enter, Backspace, Tab, arrows: the matching editing keys.
+
+Rotating the phone rotates and resizes the mirror.
+
 ## Tested on
 
 Hosts:
 - Debian, KDE/Wayland
 - Ubuntu 26.04, GNOME/Wayland
 - Arch Linux, BSPWM
+- Windows 11 x64
 
 Devices:
 
@@ -251,11 +249,10 @@ and `dpkg-deb`.
 
 ## Scope
 
-ioscpy is for controlling your own jailbroken iPhone from your Mac and Linux (Debian, Ubuntu and Arch Linux) device, over the USB
-cable, on the same desk.
+ioscpy is for controlling your own jailbroken iPhone from your Mac and Linux (Debian, Ubuntu and Arch Linux) device, over the USB cable, on the same desk.
 
 For Linux hosts, same external requirement as macOS: libimobiledevice tools (`iproxy`,
   `idevice_id`, `ideviceinfo`) and `usbmuxd`.
 
 It now runs on Windows too, reusing the standard iOS USB tools without replacing
-any driver. It is still only for iPhones that are jailbroken.
+any driver. It is still **ONLY** jailbroken iPhones.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,50 @@ sure `$HOME/.local/bin` is on your `PATH`.
 H.264 decoding works on Linux through the `openh264` software decoder. Pass
 `--mjpeg` if you prefer the MJPEG path.
 
+## Windows
+
+There is no prebuilt for Windows yet. Build the host from source. The device
+package is the same as on macOS and Linux, installed from the Sileo/Zebra repo.
+
+ioscpy on Windows reuses the USB tooling an iOS setup already has, and does **not**
+replace any driver, so Frida, objection, ideviceinfo, and iTunes keep working
+while it runs.
+
+### 1. USB stack (talk to the iPhone)
+
+- **Apple Mobile Device Support** — installed with iTunes from apple.com (get the
+  Apple-website build, not the Microsoft Store one), or the standalone AMDS
+  package. This provides the USB driver and usbmuxd. iTunes must see the phone.
+- **libimobiledevice-win32** — provides `iproxy.exe`, `idevice_id.exe`,
+  `ideviceinfo.exe`. Install with [Scoop](https://scoop.sh):
+
+      scoop install libimobiledevice
+
+  or with MSYS2:
+
+      pacman -S mingw-w64-x86_64-libimobiledevice
+
+  Make sure the three `.exe`s are on your `PATH` (or drop them next to
+  `ioscpy.exe`). Check with `idevice_id -l` — it should print your device UDID.
+
+### 2. Build toolchain
+
+- **Rust** with the MSVC toolchain — install from [rustup.rs](https://rustup.rs).
+- **Visual Studio Build Tools** with the C++ workload (the `openh264` decoder
+  compiles a small C library through `cc`).
+- **nasm** on `PATH` — `openh264`'s assembler (`scoop install nasm`).
+
+### 3. Build and run
+
+    git clone https://github.com/lautarovculic/ioscpy
+    cd ioscpy
+    cargo build --release --manifest-path host/Cargo.toml
+    .\host\target\release\ioscpy.exe --list      # confirms the device is seen
+    .\host\target\release\ioscpy.exe             # opens the mirror window
+
+Pass `--mjpeg` if you prefer the MJPEG path over H.264. If `openh264` fails to
+build, confirm `nasm` is on `PATH`.
+
 ## Tested on
 
 Hosts:
@@ -213,4 +257,5 @@ cable, on the same desk.
 For Linux hosts, same external requirement as macOS: libimobiledevice tools (`iproxy`,
   `idevice_id`, `ideviceinfo`) and `usbmuxd`.
 
-It is not for Windows, and not for iPhones that are not jailbroken.
+It now runs on Windows too, reusing the standard iOS USB tools without replacing
+any driver. It is still only for iPhones that are jailbroken.

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ ioscpy on Windows reuses the USB tooling an iOS setup already has, and does **no
 
 ### 1. USB stack
 
-- **Apple Mobile Device Support**  installed with iTunes from apple.com (get the
+- **Apple Mobile Device Support**: installed with iTunes from apple.com (get the
   Apple-website build, not the Microsoft Store one), or the standalone AMDS
   package. This provides the USB driver and usbmuxd. iTunes must see the phone.
-- **libimobiledevice-win32**  provides `iproxy.exe`, `idevice_id.exe`,
+- **libimobiledevice-win32**: provides `iproxy.exe`, `idevice_id.exe`,
   `ideviceinfo.exe`. Install with [Scoop](https://scoop.sh):
 
       scoop install libimobiledevice
@@ -147,14 +147,14 @@ ioscpy on Windows reuses the USB tooling an iOS setup already has, and does **no
       pacman -S mingw-w64-x86_64-libimobiledevice
 
   Make sure the three `.exe` files are on your `PATH` (or drop them next to
-  `ioscpy.exe`). Check with `idevice_id -l`  it should print your device UDID.
+  `ioscpy.exe`). Check with `idevice_id -l`, which should print your device UDID.
 
 ### 2. Build toolchain
 
-- **Rust** with the MSVC toolchain  install from [rustup.rs](https://rustup.rs).
+- **Rust** with the MSVC toolchain: install from [rustup.rs](https://rustup.rs).
 - **Visual Studio Build Tools** with the C++ workload (the `openh264` decoder
   compiles a small C library through `cc`).
-- **nasm** on `PATH`  `openh264`'s assembler (`scoop install nasm`).
+- **nasm** on `PATH`: `openh264`'s assembler (`scoop install nasm`).
 
 ### 3. Build and run
 
@@ -170,9 +170,9 @@ build, confirm `nasm` is on `PATH`.
 ## First touch
 
 > After a respring or a fresh connection, give the phone one physical tap on its
-> screen before driving it from the Host. iOS only trusts touch events that come
+> screen before driving it from the host. iOS only trusts touch events that come
 > from the real digitizer, so that first real tap is what lets the injected ones
-> through. You do it once, then the Host takes over.
+> through. You do it once, then the host takes over.
 
 ## Controls
 
@@ -184,6 +184,9 @@ build, confirm `nasm` is on `PATH`.
 - Cmd+A, Cmd+C, Cmd+V, Cmd+X, Cmd+Z: Select All, Copy, Paste, Cut, Undo. The
   clipboard syncs both ways, so Cmd+C on the phone reaches the Mac.
 - Enter, Backspace, Tab, arrows: the matching editing keys.
+
+On Linux and Windows, use **Ctrl** in place of Cmd for these shortcuts (Ctrl+C,
+Ctrl+V, and so on); the clipboard still syncs both ways.
 
 Rotating the phone rotates and resizes the mirror.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - [ ] Performance optimization
 - [ ] Custom Buttons Actions (Macros)
 
-A macOS and Linux CLI that mirrors and controls a jailbroken iPhone over USB.
+A macOS, Linux, and Windows CLI that mirrors and controls a jailbroken iPhone over USB.
 
 With one device attached, that is all you need. It connects on its own.
 
@@ -130,9 +130,9 @@ H.264 decoding works on Linux through the `openh264` software decoder. Pass
 
 There is no prebuilt for Windows yet. Build the host from source. The device package is the same as on macOS and Linux, installed from the Sileo/Zebra repo.
 
-ioscpy on Windows reuses the USB tooling an iOS setup already has, and does **not** replace any driver, so Frida, objection, ideviceinfo, and iTunes, grapefruit and any tool that uses it keep working while it runs.
+ioscpy on Windows reuses the USB tooling an iOS setup already has, and does **not** replace any driver, so Frida, objection, grapefruit, ideviceinfo, iTunes, and any other usbmux tool keep working while it runs.
 
-### 1. USB stack 
+### 1. USB stack
 
 - **Apple Mobile Device Support**  installed with iTunes from apple.com (get the
   Apple-website build, not the Microsoft Store one), or the standalone AMDS
@@ -146,7 +146,7 @@ ioscpy on Windows reuses the USB tooling an iOS setup already has, and does **no
 
       pacman -S mingw-w64-x86_64-libimobiledevice
 
-  Make sure the three `.exe` are on your `PATH` (or drop them next to
+  Make sure the three `.exe` files are on your `PATH` (or drop them next to
   `ioscpy.exe`). Check with `idevice_id -l`  it should print your device UDID.
 
 ### 2. Build toolchain
@@ -228,7 +228,7 @@ this in. Rootful and other iOS versions especially need testing.
 ## Layout
 
 ```text
-host/       Rust host CLI (macOS and Linux)
+host/       Rust host CLI (macOS, Linux, and Windows)
 device/     iOS package (Theos): daemon, ctl, tweak, jbcompat, packaging
 protocol/   wire format docs, kept in lockstep with the code
 scripts/    device deploy, respring, log, and diagnostics helpers

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -515,6 +515,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -590,6 +601,7 @@ dependencies = [
  "clap",
  "cocoa",
  "ctrlc",
+ "getrandom 0.2.17",
  "minifb",
  "objc",
  "openh264",
@@ -1307,6 +1319,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -515,17 +515,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -601,7 +590,7 @@ dependencies = [
  "clap",
  "cocoa",
  "ctrlc",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "minifb",
  "objc",
  "openh264",
@@ -1319,12 +1308,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -48,7 +48,9 @@ arboard = { version = "3", default-features = false, features = ["wayland-data-c
 # which doesn't build here), plus getrandom for the handshake nonce (no /dev/urandom).
 [target.'cfg(target_os = "windows")'.dependencies]
 arboard = { version = "3", default-features = false }
-getrandom = "0.2"
+# 0.3 (uses getrandom::fill) aligns with the version already in the tree, avoiding
+# an extra major line in Cargo.lock.
+getrandom = "0.3"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cc = "1"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -38,8 +38,17 @@ cocoa = "0.25"
 # openh264 is the software H.264 decoder used off macOS, since the VideoToolbox
 # shim in h264_decoder.m is mac-only.
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
 openh264 = "0.9"
+
+# Linux / other Unix (not macOS): native Wayland clipboard via wl-clipboard-rs.
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+
+# Windows: Win32 clipboard (the wayland-data-control feature pulls wl-clipboard-rs,
+# which doesn't build here), plus getrandom for the handshake nonce (no /dev/urandom).
+[target.'cfg(target_os = "windows")'.dependencies]
+arboard = { version = "3", default-features = false }
+getrandom = "0.2"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cc = "1"

--- a/host/src/device.rs
+++ b/host/src/device.rs
@@ -25,11 +25,13 @@ impl Device {
 }
 
 fn run(cmd: &str, args: &[&str]) -> Result<String> {
-    let out = Command::new(cmd)
+    let exe = crate::platform::tool_path(cmd)
+        .ok_or_else(|| anyhow!("couldn't find `{cmd}`. {}", crate::platform::missing_tools_hint()))?;
+    let out = Command::new(&exe)
         .args(args)
         .output()
         .with_context(|| {
-            format!("couldn't run `{cmd}`. The USB tools are missing. Install them with:  brew install libimobiledevice")
+            format!("couldn't run `{cmd}`. {}", crate::platform::missing_tools_hint())
         })?;
     if !out.status.success() {
         bail!(

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -15,6 +15,7 @@ mod installer;
 mod keyboard;
 mod logging;
 mod mouse;
+mod platform;
 mod protocol;
 mod sidebar;
 mod update;
@@ -23,7 +24,6 @@ mod video;
 mod window;
 
 use std::net::TcpStream;
-use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -561,7 +561,7 @@ fn reconnect_wait(stop: &Arc<AtomicBool>) -> bool {
 /// Diagnostics header for `--debug`.
 fn print_debug_header(cli: &Cli) {
     eprintln!("ioscpy {HOST_VERSION}");
-    eprintln!("macOS  {}", macos_version());
+    eprintln!("os     {}", platform::os_version());
     eprintln!(
         "target {}",
         cli.addr
@@ -569,14 +569,4 @@ fn print_debug_header(cli: &Cli) {
             .or_else(|| cli.device.clone())
             .unwrap_or_else(|| "auto (single attached device)".to_string())
     );
-}
-
-fn macos_version() -> String {
-    Command::new("sw_vers")
-        .arg("-productVersion")
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/host/src/platform/mod.rs
+++ b/host/src/platform/mod.rs
@@ -1,0 +1,83 @@
+//! Platform seam: every Windows-vs-Unix difference lives behind these four
+//! functions, so the rest of the host stays platform-neutral.
+
+use std::path::PathBuf;
+
+#[cfg(target_os = "windows")]
+#[path = "windows.rs"]
+mod imp;
+#[cfg(not(target_os = "windows"))]
+#[path = "unix.rs"]
+mod imp;
+
+/// Resolve a libimobiledevice CLI (`iproxy`, `idevice_id`, `ideviceinfo`) to a
+/// runnable path. `None` means it is not installed / not found.
+pub fn tool_path(name: &str) -> Option<PathBuf> {
+    imp::tool_path(name)
+}
+
+/// Per-OS cache directory, created if missing.
+pub fn cache_dir() -> Option<PathBuf> {
+    imp::cache_dir()
+}
+
+/// Human OS string for the `--debug` header.
+pub fn os_version() -> String {
+    imp::os_version()
+}
+
+/// One actionable line on how to install the USB tools on this OS.
+pub fn missing_tools_hint() -> &'static str {
+    imp::missing_tools_hint()
+}
+
+/// Return the first `dirs` entry that contains a file named `name{exe_suffix}`.
+/// Platform-neutral so it is unit-testable; the OS layers supply `exe_suffix`
+/// (".exe" on Windows, "" elsewhere) and the directory list.
+#[allow(dead_code)]
+pub(crate) fn resolve_in_dirs(
+    name: &str,
+    exe_suffix: &str,
+    dirs: impl IntoIterator<Item = PathBuf>,
+) -> Option<PathBuf> {
+    let filename = format!("{name}{exe_suffix}");
+    for dir in dirs {
+        let cand = dir.join(&filename);
+        if cand.is_file() {
+            return Some(cand);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_tmp() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let mut p = std::env::temp_dir();
+        p.push(format!("ioscpy-test-{}-{nanos}", std::process::id()));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn resolves_first_dir_that_has_the_file() {
+        let d1 = unique_tmp();
+        let d2 = unique_tmp();
+        let target = d2.join("iproxy.exe");
+        fs::write(&target, b"x").unwrap();
+
+        let got = resolve_in_dirs("iproxy", ".exe", vec![d1.clone(), d2.clone()]);
+        assert_eq!(got, Some(target));
+
+        let none = resolve_in_dirs("nope", ".exe", vec![d1, d2]);
+        assert_eq!(none, None);
+    }
+}

--- a/host/src/platform/unix.rs
+++ b/host/src/platform/unix.rs
@@ -1,6 +1,7 @@
 //! macOS + Linux implementation of the platform seam. This reproduces the
 //! behavior the host had before the seam existed: bare tool names resolved by
-//! `Command` via PATH, the macOS cache dir, `sw_vers`/`uname`, and the existing
+//! `Command` via PATH, the per-OS cache dir (macOS `~/Library/Caches/ioscpy`,
+//! Linux `$XDG_CACHE_HOME`/`~/.cache`), `sw_vers`/`uname`, and the existing
 //! install hints.
 
 use std::path::PathBuf;

--- a/host/src/platform/unix.rs
+++ b/host/src/platform/unix.rs
@@ -1,0 +1,65 @@
+//! macOS + Linux implementation of the platform seam. This reproduces the
+//! behavior the host had before the seam existed: bare tool names resolved by
+//! `Command` via PATH, the macOS cache dir, `sw_vers`/`uname`, and the existing
+//! install hints.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Return the bare name; `Command` resolves it through PATH, exactly as before.
+/// Always `Some`, so the spawn site keeps its original "fails at exec" behavior.
+pub fn tool_path(name: &str) -> Option<PathBuf> {
+    Some(PathBuf::from(name))
+}
+
+pub fn cache_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var_os("HOME")?;
+        let mut p = PathBuf::from(home);
+        p.push("Library/Caches/ioscpy");
+        let _ = std::fs::create_dir_all(&p);
+        Some(p)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let mut p = if let Some(x) = std::env::var_os("XDG_CACHE_HOME") {
+            PathBuf::from(x)
+        } else {
+            let home = std::env::var_os("HOME")?;
+            let mut h = PathBuf::from(home);
+            h.push(".cache");
+            h
+        };
+        p.push("ioscpy");
+        let _ = std::fs::create_dir_all(&p);
+        Some(p)
+    }
+}
+
+pub fn os_version() -> String {
+    #[cfg(target_os = "macos")]
+    let (cmd, args): (&str, &[&str]) = ("sw_vers", &["-productVersion"]);
+    #[cfg(not(target_os = "macos"))]
+    let (cmd, args): (&str, &[&str]) = ("uname", &["-sr"]);
+
+    Command::new(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+pub fn missing_tools_hint() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "The USB tools are missing. Install them with:  brew install libimobiledevice"
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "The USB tools are missing. Install them with:  sudo apt install libimobiledevice-utils usbmuxd"
+    }
+}

--- a/host/src/platform/windows.rs
+++ b/host/src/platform/windows.rs
@@ -1,0 +1,46 @@
+//! Windows implementation of the platform seam. Reaches the device through the
+//! installed libimobiledevice-win32 CLIs, which talk to Apple's usbmuxd
+//! (127.0.0.1:27015) from Apple Mobile Device Support. No USB driver is touched.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Resolve a CLI to a full path: search PATH, then the directory of the running
+/// `ioscpy.exe` (so a user can drop `iproxy.exe` next to it). `.exe` is appended.
+pub fn tool_path(name: &str) -> Option<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    if let Some(path) = std::env::var_os("PATH") {
+        dirs.extend(std::env::split_paths(&path));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            dirs.push(dir.to_path_buf());
+        }
+    }
+    super::resolve_in_dirs(name, ".exe", dirs)
+}
+
+pub fn cache_dir() -> Option<PathBuf> {
+    let base = std::env::var_os("LOCALAPPDATA")?;
+    let mut p = PathBuf::from(base);
+    p.push("ioscpy");
+    let _ = std::fs::create_dir_all(&p);
+    Some(p)
+}
+
+pub fn os_version() -> String {
+    // `cmd /C ver` prints something like "Microsoft Windows [Version 10.0.22631.0]".
+    Command::new("cmd")
+        .args(["/C", "ver"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "Windows".to_string())
+}
+
+pub fn missing_tools_hint() -> &'static str {
+    "Install Apple Mobile Device Support (from iTunes) and libimobiledevice-win32, \
+     then put iproxy.exe and idevice_id.exe on your PATH or next to ioscpy.exe."
+}

--- a/host/src/platform/windows.rs
+++ b/host/src/platform/windows.rs
@@ -42,5 +42,6 @@ pub fn os_version() -> String {
 
 pub fn missing_tools_hint() -> &'static str {
     "Install Apple Mobile Device Support (from iTunes) and libimobiledevice-win32, \
-     then put iproxy.exe and idevice_id.exe on your PATH or next to ioscpy.exe."
+     then put iproxy.exe, idevice_id.exe, and ideviceinfo.exe on your PATH or next \
+     to ioscpy.exe."
 }

--- a/host/src/protocol.rs
+++ b/host/src/protocol.rs
@@ -394,10 +394,17 @@ pub struct DaemonError {
 /// Short random hex string from the OS RNG. No crypto crate needed, the
 /// handshake nonce just has to be unique.
 pub fn random_hex(bytes: usize) -> String {
-    use std::fs::File;
     let mut buf = vec![0u8; bytes];
-    if let Ok(mut f) = File::open("/dev/urandom") {
-        let _ = f.read_exact(&mut buf);
+    #[cfg(not(target_os = "windows"))]
+    {
+        use std::io::Read;
+        if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
+            let _ = f.read_exact(&mut buf);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = getrandom::getrandom(&mut buf);
     }
     buf.iter().map(|b| format!("{b:02x}")).collect()
 }

--- a/host/src/protocol.rs
+++ b/host/src/protocol.rs
@@ -395,16 +395,30 @@ pub struct DaemonError {
 /// handshake nonce just has to be unique.
 pub fn random_hex(bytes: usize) -> String {
     let mut buf = vec![0u8; bytes];
-    #[cfg(not(target_os = "windows"))]
-    {
-        use std::io::Read;
-        if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
-            let _ = f.read_exact(&mut buf);
+    let filled = {
+        #[cfg(not(target_os = "windows"))]
+        {
+            use std::io::Read;
+            std::fs::File::open("/dev/urandom")
+                .and_then(|mut f| f.read_exact(&mut buf))
+                .is_ok()
         }
-    }
-    #[cfg(target_os = "windows")]
-    {
-        let _ = getrandom::getrandom(&mut buf);
+        #[cfg(target_os = "windows")]
+        {
+            getrandom::fill(&mut buf).is_ok()
+        }
+    };
+    if !filled {
+        // OS RNG unavailable (very rare). Seed from time + pid so the nonce is
+        // still unique per call instead of the all-zero buffer above.
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+            ^ u128::from(std::process::id());
+        for (i, b) in buf.iter_mut().enumerate() {
+            *b = (seed >> ((i % 16) * 8)) as u8 ^ (i as u8);
+        }
     }
     buf.iter().map(|b| format!("{b:02x}")).collect()
 }

--- a/host/src/update.rs
+++ b/host/src/update.rs
@@ -16,10 +16,7 @@ const REFRESH_SECS: u64 = 24 * 60 * 60;
 
 /// Where the last known release version is cached.
 fn cache_path() -> Option<PathBuf> {
-    let home = std::env::var_os("HOME")?;
-    let mut p = PathBuf::from(home);
-    p.push("Library/Caches/ioscpy");
-    let _ = fs::create_dir_all(&p);
+    let mut p = crate::platform::cache_dir()?;
     p.push("latest_version");
     Some(p)
 }

--- a/host/src/usbmux.rs
+++ b/host/src/usbmux.rs
@@ -44,7 +44,9 @@ impl UsbForward {
         let local_port = free_local_port()?;
         let pair = format!("{local_port}:{device_port}");
 
-        let mut child = Command::new("iproxy")
+        let iproxy = crate::platform::tool_path("iproxy")
+            .ok_or_else(|| anyhow::anyhow!("{}", crate::platform::missing_tools_hint()))?;
+        let mut child = Command::new(&iproxy)
             .arg(&pair)
             .arg("-u")
             .arg(udid)
@@ -52,7 +54,9 @@ impl UsbForward {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .context("couldn't start the USB link. The USB tools are missing. Install them with:  brew install libimobiledevice")?;
+            .with_context(|| {
+                format!("couldn't start the USB link. {}", crate::platform::missing_tools_hint())
+            })?;
 
         let deadline = Instant::now() + Duration::from_secs(6);
         loop {


### PR DESCRIPTION
## Summary

Makes the ioscpy host build and run on Windows. Host-only port: the device package (tweak + ioscpyd), the wire protocol (v4), and the capture/inject pipeline are untouched. A Windows user installs the same .deb from the existing Sileo/Zebra repo.

Same coexistence model as Linux: reach the device through installed libimobiledevice CLIs talking to Apple's usbmuxd. No USB driver is replaced, Frida, objection, grapefruit, ideviceinfo, and iTunes keep working concurrently.

### What changed

- New host/src/platform seam: isolates every Windows-vs-Unix difference behind tool_path/cache_dir/os_version/missing_tools_hint; unix.rs reproduces today's exact behavior (no change off Windows).
- Routed 4 macOS-hardcoded call sites through it.
- Windows entropy: random_hex()'s /dev/urandom doesn't exist on Windows; added getrandom branch.
- Clipboard: split arboard by target (drop wayland-data-control on Windows only; Linux Wayland unaffected).
- README: Windows section + scope/layout.


### Relationship to #8

> This overlaps with #8 by @cykrr, which also ports the host to Windows over usbmux; full credit to that effort for getting there first and for surfacing two real issues. This PR takes a different structural approach (a centralized platform seam and native MSVC rather than scattered cfg! and MinGW), and it adopts the two fixes #8 caught: the getrandom entropy source, and the clipboard-feature problem here is resolved by splitting the arboard feature per target so Linux Wayland isn't regressed, rather than dropping it globally.


### Testing

- Windows 11 x64 — tested on a real jailbroken iPhone: live mirror + control all working.
- Linux — build, test (4/4), clippy clean.
- macOS — unchanged by design; no Mac to rebuild on (routing-only diff).