### PR TITLE
Linux: decorated window on GNOME/Wayland (fixes #4) + one-script installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,12 @@ packaging/repo/out/
 __pycache__/
 *.pyc
 
+# Private planning docs, never published.
+priv-docs/
+
 # Secrets. Never commit device credentials, keys, or session tokens.
 *.pem
 id_rsa*
 *.token
 secrets.env
 .env
-docs/linux-h264.md
-docs/windows/

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ clean:
 help:
 	@echo "ioscpy targets:"
 	@echo "  make install           run the Linux installer (deps + build + install)"
-	@echo "  make host-release      build macOS host binary (release)"
+	@echo "  make host-release      build the host binary (release)"
 	@echo "  make install-host      install ioscpy to $(PREFIX)/bin (on PATH)"
 	@echo "  make device-rootless   build rootless .deb (/var/jb)"
 	@echo "  make device-rootful    build rootful .deb (/)"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ioscpy top-level build orchestration.
 # Author: Lautaro Villarreal Culic' (https://lautarovculic.com)
 
-.PHONY: all host host-release install-host uninstall-host device device-rootless \
+.PHONY: all host host-release install install-host uninstall-host device device-rootless \
         device-rootful device-roothide release repo clean fmt clippy test help
 
 PREFIX ?= /usr/local
@@ -14,6 +14,9 @@ host:
 
 host-release:
 	cd host && cargo build --release
+
+install:
+	./install.sh
 
 # No host-release dependency on purpose: this target is usually run with sudo,
 # and root's PATH does not see a rustup-installed cargo. Build as your user
@@ -67,6 +70,7 @@ clean:
 
 help:
 	@echo "ioscpy targets:"
+	@echo "  make install           run the Linux installer (deps + build + install)"
 	@echo "  make host-release      build macOS host binary (release)"
 	@echo "  make install-host      install ioscpy to $(PREFIX)/bin (on PATH)"
 	@echo "  make device-rootless   build rootless .deb (/var/jb)"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ sure `$HOME/.local/bin` is on your `PATH`.
 H.264 decoding works on Linux through the `openh264` software decoder. Pass
 `--mjpeg` if you prefer the MJPEG path.
 
+On Wayland compositors that refuse server-side decorations (GNOME/mutter),
+ioscpy automatically falls back to X11/XWayland so the window gets a normal
+titlebar. Pass `--wayland` to stay on native Wayland instead.
+
 ## Windows
 
 There is no prebuilt for Windows yet. Build the host from source. The device package is the same as on macOS and Linux, installed from the Sileo/Zebra repo.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ ioscpy --version
 There is no prebuilt for Linux yet. Build the host from source. The device
 package is the same as on macOS, installed from the Sileo/Zebra repo above.
 
+Clone this repo, then run the installer:
+
+```bash
+./install.sh
+```
+
+`--yes` skips the confirmation prompts. `--prefix DIR` installs to `DIR` instead of `/usr/local` and omits `sudo` when the directory is under `$HOME`. `--uninstall` removes the installed binary.
+
+### Manual install
+
 Prereqs on Debian/Ubuntu:
 
 ```bash
@@ -82,6 +92,8 @@ ioscpy --version
 ```
 
 ## For Arch Linux
+
+`./install.sh` also works on Arch Linux.
 
 ```bash
 sudo pacman -S --needed \

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "wayland-client 0.31.14",
  "zune-jpeg",
 ]
 

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -41,8 +41,11 @@ cocoa = "0.25"
 openh264 = "0.9"
 
 # Linux / other Unix (not macOS): native Wayland clipboard via wl-clipboard-rs.
+# wayland-client (same 0.31 line wl-clipboard-rs already pulls in) is used only
+# to probe the compositor for server-side decoration support (see wayland_compat.rs).
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+wayland-client = "0.31"
 
 # Windows: Win32 clipboard (the wayland-data-control feature pulls wl-clipboard-rs,
 # which doesn't build here), plus getrandom for the handshake nonce (no /dev/urandom).

--- a/host/src/cli.rs
+++ b/host/src/cli.rs
@@ -30,6 +30,12 @@ pub struct Cli {
     #[arg(long)]
     pub mjpeg: bool,
 
+    /// Stay on native Wayland even when the compositor draws no window
+    /// decorations for us (GNOME/mutter). By default ioscpy falls back to
+    /// X11/XWayland there so the window gets a titlebar. Linux only.
+    #[arg(long)]
+    pub wayland: bool,
+
     /// Hide the on-screen iOS keyboard while connected, so the mirror shows the
     /// full screen (you type from the Mac; the device acts as if a hardware
     /// keyboard is attached). The keyboard returns when ioscpy exits. iOS 16+.

--- a/host/src/cli.rs
+++ b/host/src/cli.rs
@@ -32,7 +32,8 @@ pub struct Cli {
 
     /// Stay on native Wayland even when the compositor draws no window
     /// decorations for us (GNOME/mutter). By default ioscpy falls back to
-    /// X11/XWayland there so the window gets a titlebar. Linux only.
+    /// X11/XWayland there so the window gets a titlebar.
+    #[cfg(all(unix, not(target_os = "macos")))]
     #[arg(long)]
     pub wayland: bool,
 

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -21,6 +21,8 @@ mod sidebar;
 mod update;
 mod usbmux;
 mod video;
+#[cfg(all(unix, not(target_os = "macos")))]
+mod wayland_compat;
 mod window;
 
 use std::net::TcpStream;
@@ -39,6 +41,11 @@ const HOST_VERSION: &str = env!("CARGO_PKG_VERSION");
 fn main() {
     let cli = Cli::parse_args();
     logging::set_debug(cli.debug);
+
+    // Must run before any thread is spawned or window/clipboard is created:
+    // it may unset WAYLAND_DISPLAY for this process (issue #4).
+    #[cfg(all(unix, not(target_os = "macos")))]
+    wayland_compat::apply_decoration_workaround(cli.wayland);
 
     if let Err(e) = run(&cli) {
         eprintln!("ioscpy: error: {e:#}");

--- a/host/src/wayland_compat.rs
+++ b/host/src/wayland_compat.rs
@@ -1,0 +1,79 @@
+//! Workaround for compositors without server-side decorations (issue #4).
+//!
+//! minifb's Wayland backend requests decorations via `zxdg_decoration_manager_v1`
+//! and has no client-side fallback, so on compositors that refuse server-side
+//! decorations (GNOME/mutter) the window comes up with no titlebar, no resize
+//! handles and no close button. KDE/KWin and wlroots compositors advertise the
+//! protocol and are fine.
+//!
+//! Instead of asking users to run `WAYLAND_DISPLAY= ioscpy`, we probe the
+//! compositor's global registry once at startup: if it does not advertise
+//! `zxdg_decoration_manager_v1`, we unset `WAYLAND_DISPLAY` for this process so
+//! minifb (and the clipboard) fall back to X11/XWayland, which decorates the
+//! window normally. `--wayland` opts out and keeps the native connection.
+
+use wayland_client::{
+    protocol::wl_registry::{Event as RegistryEvent, WlRegistry},
+    Connection, Dispatch, QueueHandle,
+};
+
+const DECORATION_MANAGER: &str = "zxdg_decoration_manager_v1";
+
+struct Probe {
+    has_decoration_manager: bool,
+}
+
+impl Dispatch<WlRegistry, ()> for Probe {
+    fn event(
+        state: &mut Self,
+        _registry: &WlRegistry,
+        event: RegistryEvent,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let RegistryEvent::Global { interface, .. } = event {
+            if interface == DECORATION_MANAGER {
+                state.has_decoration_manager = true;
+            }
+        }
+    }
+}
+
+/// True if the compositor advertises server-side decorations, None if we could
+/// not talk to it at all (then we leave the environment alone and let minifb
+/// surface whatever error there is).
+fn compositor_has_server_decorations() -> Option<bool> {
+    let conn = Connection::connect_to_env().ok()?;
+    let display = conn.display();
+    let mut queue = conn.new_event_queue();
+    let qh = queue.handle();
+    display.get_registry(&qh, ());
+    let mut probe = Probe {
+        has_decoration_manager: false,
+    };
+    // One roundtrip is enough: the registry announces every global before the
+    // sync callback fires.
+    queue.roundtrip(&mut probe).ok()?;
+    Some(probe.has_decoration_manager)
+}
+
+/// Call once at startup, before any window or clipboard is created and before
+/// any thread is spawned (this may mutate the process environment).
+pub fn apply_decoration_workaround(keep_native_wayland: bool) {
+    if std::env::var_os("WAYLAND_DISPLAY").map_or(true, |v| v.is_empty()) {
+        return; // not a Wayland session (or already masked by the user)
+    }
+    if keep_native_wayland {
+        return;
+    }
+    if compositor_has_server_decorations() != Some(false) {
+        return;
+    }
+    std::env::remove_var("WAYLAND_DISPLAY");
+    eprintln!(
+        "ioscpy: this Wayland compositor draws no window decorations for us \
+         (no {DECORATION_MANAGER}); using X11/XWayland instead. \
+         Pass --wayland to keep native Wayland."
+    );
+}

--- a/host/src/wayland_compat.rs
+++ b/host/src/wayland_compat.rs
@@ -58,10 +58,17 @@ fn compositor_has_server_decorations() -> Option<bool> {
     Some(probe.has_decoration_manager)
 }
 
+fn env_set(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|v| !v.is_empty())
+}
+
 /// Call once at startup, before any window or clipboard is created and before
 /// any thread is spawned (this may mutate the process environment).
 pub fn apply_decoration_workaround(keep_native_wayland: bool) {
-    if std::env::var_os("WAYLAND_DISPLAY").map_or(true, |v| v.is_empty()) {
+    // WAYLAND_SOCKET (an inherited connection fd) takes precedence over
+    // WAYLAND_DISPLAY in libwayland and wayland-client alike, so either one
+    // means minifb would connect to Wayland.
+    if !env_set("WAYLAND_DISPLAY") && !env_set("WAYLAND_SOCKET") {
         return; // not a Wayland session (or already masked by the user)
     }
     if keep_native_wayland {
@@ -71,6 +78,7 @@ pub fn apply_decoration_workaround(keep_native_wayland: bool) {
         return;
     }
     std::env::remove_var("WAYLAND_DISPLAY");
+    std::env::remove_var("WAYLAND_SOCKET");
     eprintln!(
         "ioscpy: this Wayland compositor draws no window decorations for us \
          (no {DECORATION_MANAGER}); using X11/XWayland instead. \

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX=/usr/local
+YES=0
+UNINSTALL=0
+PM=
+
+usage() {
+    cat <<EOF
+Usage: ./install.sh [--yes] [--prefix DIR] [--uninstall] [--help]
+
+  --yes       Skip confirmation prompts.
+  --prefix    Install directory (default: /usr/local).
+  --uninstall Remove the installed binary.
+  --help      Show this message.
+EOF
+}
+
+err() {
+    echo "install.sh: $*" >&2
+}
+
+abort() {
+    err "$@"
+    exit 1
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes)
+                YES=1
+                shift
+                ;;
+            --prefix)
+                if [[ $# -lt 2 ]]; then
+                    abort "--prefix requires an argument"
+                fi
+                PREFIX="$2"
+                shift 2
+                ;;
+            --uninstall)
+                UNINSTALL=1
+                shift
+                ;;
+            --help)
+                usage
+                exit 0
+                ;;
+            *)
+                usage >&2
+                exit 2
+                ;;
+        esac
+    done
+}
+
+refuse_root() {
+    if [[ $EUID -eq 0 ]]; then
+        abort "run as your normal user; the script uses sudo only where needed"
+    fi
+}
+
+check_repo() {
+    if [[ ! -f Makefile ]] || [[ ! -f host/Cargo.toml ]]; then
+        abort "run from a full clone"
+    fi
+}
+
+detect_distro() {
+    local id="" id_like=""
+    if [[ -f /etc/os-release ]]; then
+        # shellcheck source=/dev/null
+        . /etc/os-release
+        id="$ID"
+        id_like="${ID_LIKE:-}"
+    fi
+
+    if [[ " $id " == *" debian "* ]] || [[ " $id " == *" ubuntu "* ]]; then
+        PM=apt
+    elif [[ " $id_like " == *" debian "* ]] || [[ " $id_like " == *" ubuntu "* ]]; then
+        PM=apt
+    elif [[ " $id " == *" arch "* ]]; then
+        PM=pacman
+    elif [[ " $id_like " == *" arch "* ]]; then
+        PM=pacman
+    else
+        abort "unsupported distro — follow the manual steps in README.md (Linux section)"
+    fi
+}
+
+check_rust() {
+    if ! command -v cargo >/dev/null 2>&1; then
+        err "cargo not found. Install Rust with:"
+        err "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+        exit 1
+    fi
+
+    if ! cargo --version >/dev/null 2>&1; then
+        err "cargo is installed but does not run. Fix with:"
+        err "  rustup default stable"
+        exit 1
+    fi
+}
+
+prompt() {
+    local response
+    if [[ $YES -eq 1 ]]; then
+        return 0
+    fi
+    printf "%s [y/N] " "$1"
+    read -r response
+    [[ "$response" == "y" || "$response" == "Y" ]]
+}
+
+install_deps() {
+    local -a cmd
+    if [[ "$PM" == "apt" ]]; then
+        cmd=(sudo apt install -y build-essential pkg-config nasm libimobiledevice-utils usbmuxd libxkbcommon-dev libwayland-dev libxcb1-dev libxkbcommon-x11-dev)
+    else
+        cmd=(sudo pacman -S --needed --noconfirm base-devel pkgconf nasm libimobiledevice usbmuxd libxkbcommon wayland libxcb libxkbcommon-x11)
+    fi
+
+    echo "Will install dependencies:"
+    printf "  %s\n" "${cmd[*]}"
+    if ! prompt "Install with sudo $PM?"; then
+        abort "dependency install cancelled"
+    fi
+
+    echo "+ ${cmd[*]}"
+    "${cmd[@]}"
+}
+
+build() {
+    echo "+ make host-release"
+    make host-release
+}
+
+install_binary() {
+    local -a cmd
+    if [[ "$PREFIX" == "$HOME" || "$PREFIX" == "$HOME"/* ]]; then
+        cmd=(make install-host PREFIX="$PREFIX")
+    else
+        cmd=(sudo make install-host PREFIX="$PREFIX")
+    fi
+    echo "+ ${cmd[*]}"
+    "${cmd[@]}"
+}
+
+do_uninstall() {
+    local target
+    target="$PREFIX/bin/ioscpy"
+    if [[ ! -e "$target" ]]; then
+        echo "nothing installed at $target"
+        exit 0
+    fi
+
+    local -a cmd
+    if [[ "$PREFIX" == "$HOME" || "$PREFIX" == "$HOME"/* ]]; then
+        cmd=(make uninstall-host PREFIX="$PREFIX")
+    else
+        cmd=(sudo make uninstall-host PREFIX="$PREFIX")
+    fi
+    echo "+ ${cmd[*]}"
+    "${cmd[@]}"
+
+    if [[ -e "$target" ]]; then
+        err "$target still exists"
+    else
+        echo "removed $target"
+    fi
+    echo "Distro packages and usbmuxd service were not removed."
+    exit 0
+}
+
+enable_usbmuxd() {
+    if systemctl is-active --quiet usbmuxd 2>/dev/null; then
+        echo "usbmuxd is already running"
+        return
+    fi
+
+    if ! command -v systemctl >/dev/null 2>&1; then
+        err "start usbmuxd manually before connecting a device"
+        return
+    fi
+
+    local -a cmd=(sudo systemctl enable --now usbmuxd)
+    echo "+ ${cmd[*]}"
+    if prompt "Enable and start usbmuxd with systemctl?"; then
+        "${cmd[@]}"
+    else
+        err "usbmuxd not started"
+    fi
+}
+
+verify() {
+    local ioscpy_path
+    ioscpy_path="$PREFIX/bin/ioscpy"
+    echo "+ \"$ioscpy_path\" --version"
+    "$ioscpy_path" --version
+
+    if ! command -v idevice_id >/dev/null 2>&1; then
+        err "idevice_id not found on PATH; install libimobiledevice-utils or libimobiledevice"
+    fi
+
+    echo
+    echo "installed: $ioscpy_path"
+    echo "plug in the iPhone and run 'idevice_id -l'"
+    echo "then run 'ioscpy'"
+}
+
+main() {
+    parse_args "$@"
+    cd "$(dirname "$0")"
+    refuse_root
+    check_repo
+
+    if [[ $UNINSTALL -eq 1 ]]; then
+        do_uninstall
+    fi
+
+    detect_distro
+    check_rust
+    install_deps
+    build
+    install_binary
+    enable_usbmuxd
+    verify
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -186,8 +186,8 @@ enable_usbmuxd() {
     fi
 
     local -a cmd=(sudo systemctl enable --now usbmuxd)
-    echo "+ ${cmd[*]}"
     if prompt "Enable and start usbmuxd with systemctl?"; then
+        echo "+ ${cmd[*]}"
         "${cmd[@]}"
     else
         err "usbmuxd not started"


### PR DESCRIPTION
Two Linux improvements: the GNOME/Wayland window-decoration fix and a one-script installer.

## 1. Fix: window decorations on GNOME/Wayland (fixes #4)

minifb's Wayland backend requests decorations through `zxdg_decoration_manager_v1` and has no client-side fallback, so on compositors that refuse server-side decorations (GNOME/mutter) the window opened with no titlebar, no resize handles, no close button.

Instead of asking users to run `WAYLAND_DISPLAY= ioscpy`, the host now probes the compositor's global registry once at startup. If `zxdg_decoration_manager_v1` is not advertised, it unsets `WAYLAND_DISPLAY` for its own process, so minifb (and the clipboard) fall back to X11/XWayland and the window gets normal decorations. Compositors that do support server-side decorations (KDE/KWin, wlroots) keep the native Wayland path untouched, and `--wayland` opts out of the fallback entirely.

- Capability probe, not a desktop-name heuristic — no `XDG_CURRENT_DESKTOP` string matching.
- `wayland-client` is the same 0.31 line `wl-clipboard-rs` already pulls in, so no new dependency tree.
- Compiled only on `cfg(all(unix, not(macos)))`; macOS and Windows builds unchanged.

Verified live on GNOME/mutter (fallback fires, window decorated) and the `--wayland` opt-out.

## 2. Feature: Linux installer (`install.sh`)

Replaces the manual install flow (distro deps, rustup, `make host-release`, `sudo make install-host`, usbmuxd enable) with:

```bash
./install.sh [--yes] [--prefix DIR] [--uninstall]
```

- Refuses to run as root; uses sudo only for the package install, the binary install (skipped when `--prefix` is under `$HOME`), and enabling usbmuxd — every sudo command is printed before it runs.
- Debian/Ubuntu (apt) and Arch (pacman); anything else gets pointed at the README's manual steps instead of guessing.
- Rust is checked but never auto-installed.
- `make install` wraps the script; the README Linux section now leads with it and keeps the manual steps as a fallback.

**Testing caveat:** exercised end-to-end on Ubuntu 26.04 only, where some dependencies were already installed. Not yet run on a clean machine with zero dependencies. `bash -n`, `shellcheck` (0 findings) and `make -n install` are clean.

## Tested on

- Ubuntu 26.04, GNOME/Wayland — full run: decoration fallback + installer end-to-end with a device attached.


